### PR TITLE
docs: add CHANGELOG and categorized release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+# Configures GitHub's auto-generated release notes (generate_release_notes: true).
+# PRs are grouped into sections by label; matching authors/labels are excluded.
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - duplicate
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    - title: 🚀 Features
+      labels: [feature, enhancement]
+    - title: 🐛 Bug Fixes
+      labels: [bug, fix]
+    - title: 🔐 Security
+      labels: [security]
+    - title: 📦 Native / Packaging
+      labels: [packaging, release, ci]
+    - title: 🧪 Tests
+      labels: [tests]
+    - title: 📚 Documentation
+      labels: [documentation, docs]
+    - title: 🔧 Maintenance
+      labels: [chore, refactor, dependencies]
+    - title: 🔄 Other Changes
+      labels: ["*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,14 +97,33 @@ jobs:
     needs: [build-linux, build-windows, build-macos]
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4      # need CHANGELOG.md at the tagged commit
       - uses: actions/download-artifact@v4
         with: { path: artifacts/ }
+      - name: Extract CHANGELOG section for this version
+        id: notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Pull the block between "## [VERSION]" and the next "## [" heading.
+          awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" {grab=1; next}
+            grab && /^## \[/ {exit}
+            grab {print}
+          ' CHANGELOG.md > release-body.md
+          if [ -s release-body.md ]; then
+            echo "has_notes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No CHANGELOG entry for $VERSION — using auto-generated notes only."
+          fi
       - uses: softprops/action-gh-release@v2
         with:
           files: |
             artifacts/linux-deb/*.deb
             artifacts/windows-zip/*.zip
             artifacts/macos-app/*.tar.gz
+          # Curated section (if present) goes first; GitHub appends the
+          # auto-generated "What's Changed" / contributors below it.
+          body_path: ${{ steps.notes.outputs.has_notes == 'true' && 'release-body.md' || '' }}
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to the AlfacodeTeam PhpServicePlatform (Sentinel) kernel are
+documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-07-07
+
+First native release — the framework ships as OS-native bundles for Linux,
+macOS, and Windows, built and published automatically from a `v*` tag.
+
+### Added
+- **Native `hkm` launcher** (Zig) for Linux, macOS (universal arm64 + x86_64),
+  and Windows, cross-compiled from a single Linux host.
+- **`hkm doctor`** — verifies PHP ≥ 8.4.1, required extensions
+  (json, mbstring, ctype, tokenizer, filter, pdo, openssl, curl, fileinfo), a
+  PDO driver, and reports the resolved kernel path.
+- **`hkm version` / `--version` / `-v`** with a Sentinel ASCII banner.
+- **`hkm upgrade [--check]`** — checks the repo's `v*` tags for a newer release
+  and updates a git-checkout install (packaged installs get reinstall guidance).
+- **Self-locating kernel** — the launcher finds the kernel relative to its own
+  executable, so `.app`/zip/portable installs need no environment variable.
+- **`tools/bundle.sh`** — assembles the `.deb`, macOS `.app` tarball, and Windows
+  `.zip`; ships source (`src`, `plugins`, `projects`, `modules`) and resolves
+  Composer dependencies on the target at install time (`vendor/` not bundled).
+  `MODULES=git` mode fetches path-repo modules from pinned commits instead.
+- **CI** (`.github/workflows/ci.yml`) — PHPUnit + Zig cross-builds on push/PR to `main`.
+- **Release** (`.github/workflows/release.yml`) — test-gated; builds all three
+  OS bundles on Linux and publishes the GitHub release automatically.
+- **Self-hosted Zig toolchain** fetch (`tools/ci/setup-zig.sh`) so CI is immune
+  to upstream purging the pinned dev build.
+- **Kernel unit test suite** (`tests/Unit/Kernel/`) — Identity, SecurityVerdict,
+  FrameworkException/ValidationException, DependencyGraphCalculator, Request,
+  Response (427 tests total, all green).
+
+### Changed
+- **Minimum PHP is now 8.4.1** (aligned with the actual Symfony 8 dependency);
+  previously advertised as 8.2+.
+- The kernel is packaged under `/opt/hkm-kernel` with `hkm` on `PATH`.
+
+### Fixed
+- PSR-4 autoloading violations: split `SeedCommands.php` into one class per file
+  and excluded path-loaded `database/{seeders,migrations,factories}` from the
+  classmap.
+- Registered the Cookie and Pageflow support helpers in Composer's `files`
+  autoload so their global functions resolve.
+- Added a tracked `phpunit.xml.dist` so CI finds the test configuration
+  (`phpunit.xml` is gitignored).
+- Windows cross-compilation: guarded POSIX-only raw-mode TTY code.
+
+[Unreleased]: https://github.com/AlfaCode-Team/php-service-platform/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/AlfaCode-Team/php-service-platform/releases/tag/v1.0.0


### PR DESCRIPTION
Adds changelog tooling so releases ship with curated + categorized notes.

## Changes
- **CHANGELOG.md** — Keep-a-Changelog format with the full `1.0.0` entry and an `Unreleased` section.
- **.github/release.yml** — groups auto-generated release notes into sections (Features/Fixes/Security/Packaging/Tests/Docs/Maintenance) by PR label; excludes bot noise.
- **release.yml** — the publish job extracts the matching `## [VERSION]` block from CHANGELOG.md into the release body; GitHub's "What's Changed" appends below. Falls back to auto-notes only if no entry exists.

Takes effect on the next `v*` tag. The live v1.0.0 notes were already backfilled manually.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native launcher and new command-line options for checking system status, viewing version info, and upgrading.
  * Improved release packaging so the app can be installed and run more consistently.

* **Bug Fixes**
  * Fixed issues with autoloading and command-line behavior in some environments.
  * Improved compatibility for Windows cross-compilation.

* **Documentation**
  * Updated the changelog with the latest release details and installation notes.

* **Chores**
  * Improved release automation so published releases include changelog notes when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
