### PR TITLE
feat(cli): show Sentinel banner on bare hkm and hkm help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-07
+
+### Changed
+- The Sentinel ASCII banner + version now shows as the header of `hkm` and
+  `hkm help` (previously only on `hkm version`).
+
 ## [1.0.0] - 2026-07-07
 
 First native release — the framework ships as OS-native bundles for Linux,

--- a/tools/src/main.zig
+++ b/tools/src/main.zig
@@ -13,7 +13,7 @@ const banner = @import("lib/banner.zig");
 const prompt = @import("lib/prompt.zig");
 
 fn printHelp() void {
-    prompt.intro("hkm launcher");
+    banner.print();
 
     prompt.section("Usage");
     prompt.item("hkm new <path> [opts]", "scaffold a new PhpServicePlatform project");


### PR DESCRIPTION
The Sentinel ASCII banner + version now headers `hkm` and `hkm help`, not just `hkm version`.

Ships in v1.0.1. CHANGELOG updated.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * The command-line header now shows the Sentinel ASCII banner and version for both `hkm` and `hkm help`, making the startup display consistent across help and version output.
  * Updated the release notes to reflect the new header behavior in version 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
