### PR TITLE
fix(cli): self-locate installed kernel + real hkm-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `hkm run` / `hkm run --pick` / the registry now **self-locate the installed
+  kernel** (`/opt/hkm-kernel`, or the dir relative to the launcher) instead of
+  only using env vars or a dev tree found by walking up from the CWD. Fixes
+  "Kernel registry not found" on packaged installs and stops an installed
+  launcher from silently using a development kernel.
+- `hkm-config` is now a real config checker: it resolves the kernel, verifies
+  `vendor/autoload.php` + the projects registry, and writes/repairs
+  `HKM_KERNEL_HOME` in `~/.config/hkm/config.env`.
+- The launcher now **loads `~/.config/hkm/config.env`** at startup (real
+  environment variables still win), so `hkm-config` settings actually apply.
+
 ## [1.0.2] - 2026-07-07
 
 ### Changed

--- a/tools/src/config.zig
+++ b/tools/src/config.zig
@@ -1,80 +1,134 @@
+//! `hkm-config` — inspect and repair the launcher's persistent configuration
+//! (`~/.config/hkm/config.env`, loaded by `hkm` at startup).
+//!
+//!   hkm-config                     # check config; auto-configure if incomplete
+//!   hkm-config check               # same as no-args
+//!   hkm-config print               # show the config file path + contents
+//!   hkm-config set-kernel-home <p> # pin HKM_KERNEL_HOME
+//!   hkm-config set-autoload <p>    # pin HKM_GLOBAL_AUTOLOAD (vendor/autoload.php)
+//!
+//! "check" resolves the kernel (env → relative to this binary → /opt/hkm-kernel)
+//! and, if the config file is missing or stale, writes HKM_KERNEL_HOME for you.
+
 const std = @import("std");
+const kernel = @import("lib/kernel.zig");
+const userconfig = @import("lib/userconfig.zig");
+const prompt = @import("lib/prompt.zig");
+const util = @import("lib/util.zig");
 
-fn printHelp() void {
-    std.debug.print(
-        "hkm-config\\n" ++
-            "Usage:\\n" ++
-            "  hkm-config print\\n" ++
-            "  hkm-config set-kernel-home <path>\\n" ++
-            "  hkm-config set-autoload <path-to-vendor/autoload.php>\\n",
-        .{},
-    );
-}
-
-fn configPath(allocator: std.mem.Allocator, env_map: *std.process.Environ.Map) ![]const u8 {
-    if (env_map.get("HOME")) |home| {
-        return try std.fmt.allocPrint(allocator, "{s}/.config/hkm/config.env", .{home});
-    }
-    return error.MissingHome;
-}
-
-fn ensureConfigDir(path: []const u8) !void {
-    const dir = std.fs.path.dirname(path) orelse return;
-    const io = std.Io.Threaded.global_single_threaded.io();
-    try std.Io.Dir.createDirPath(std.Io.Dir.cwd(), io, dir);
-}
+const Io = std.Io;
+const EnvMap = std.process.Environ.Map;
 
 pub fn main(init: std.process.Init.Minimal) !void {
-    var arena_allocator: std.heap.ArenaAllocator = .init(std.heap.page_allocator);
-    defer arena_allocator.deinit();
-    const allocator = arena_allocator.allocator();
-    var env_map = try init.environ.createMap(allocator);
-    defer env_map.deinit();
+    var arena: std.heap.ArenaAllocator = .init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    var threaded: std.Io.Threaded = .init(std.heap.page_allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+    var env = try init.environ.createMap(allocator);
+    defer env.deinit();
+
+    // Make already-saved config visible to resolution below.
+    userconfig.load(allocator, io, &env);
 
     const args = try init.args.toSlice(allocator);
-
-    if (args.len < 2) {
-        printHelp();
-        return;
-    }
-
-    const action = args[1];
-    const cfg = try configPath(allocator, &env_map);
+    const action = if (args.len >= 2) args[1] else "check";
 
     if (std.mem.eql(u8, action, "print")) {
-        std.debug.print("{s}\\n", .{cfg});
+        const p = (try userconfig.path(allocator, &env)) orelse {
+            prompt.err("cannot resolve config path (no HOME).");
+            std.process.exit(1);
+        };
+        prompt.section("Config file");
+        prompt.item("path", p);
+        if (std.Io.Dir.cwd().readFileAlloc(io, p, allocator, .limited(64 * 1024))) |c| {
+            prompt.blank();
+            std.debug.print("{s}\n", .{c});
+        } else |_| prompt.muted("(file does not exist yet — run `hkm-config` to create it)");
         return;
     }
-
-    if (args.len < 3) {
-        printHelp();
-        return;
-    }
-
-    const value = args[2];
-    try ensureConfigDir(cfg);
-
-    const io = std.Io.Threaded.global_single_threaded.io();
-    var file = try std.Io.Dir.createFile(std.Io.Dir.cwd(), io, cfg, .{ .truncate = true });
-    defer file.close(io);
-    var buffer: [512]u8 = undefined;
-    var writer = file.writer(io, &buffer);
 
     if (std.mem.eql(u8, action, "set-kernel-home")) {
-        try writer.interface.writeAll("HKM_KERNEL_HOME=");
-        try writer.interface.writeAll(value);
-        try writer.interface.writeAll("\n");
-        try writer.flush();
+        if (args.len < 3) return usage();
+        try userconfig.set(allocator, io, &env, "HKM_KERNEL_HOME", args[2]);
+        prompt.ok("HKM_KERNEL_HOME saved.");
         return;
     }
-
     if (std.mem.eql(u8, action, "set-autoload")) {
-        try writer.interface.writeAll("HKM_GLOBAL_AUTOLOAD=");
-        try writer.interface.writeAll(value);
-        try writer.interface.writeAll("\n");
-        try writer.flush();
+        if (args.len < 3) return usage();
+        try userconfig.set(allocator, io, &env, "HKM_GLOBAL_AUTOLOAD", args[2]);
+        prompt.ok("HKM_GLOBAL_AUTOLOAD saved.");
         return;
     }
+    if (std.mem.eql(u8, action, "check") or std.mem.eql(u8, action, "configure")) {
+        std.process.exit(try runCheck(allocator, io, &env));
+    }
 
-    printHelp();
+    usage();
+}
+
+fn usage() void {
+    prompt.section("hkm-config");
+    prompt.item("hkm-config", "check config; auto-configure if incomplete");
+    prompt.item("hkm-config print", "show the config file path + contents");
+    prompt.item("hkm-config set-kernel-home <p>", "pin the kernel root");
+    prompt.item("hkm-config set-autoload <p>", "pin vendor/autoload.php");
+}
+
+fn runCheck(allocator: std.mem.Allocator, io: Io, env: *EnvMap) !u8 {
+    prompt.intro("hkm-config");
+
+    const cfg = (try userconfig.path(allocator, env)) orelse {
+        prompt.err("no HOME — cannot locate ~/.config/hkm/config.env");
+        return 1;
+    };
+    prompt.section("Configuration");
+    prompt.item("config file", cfg);
+    prompt.item("exists", if (util.fileExists(io, cfg)) "yes" else "no (will create)");
+
+    // 1. Locate the kernel.
+    const home = (try kernel.resolveHome(allocator, io, env)) orelse {
+        prompt.blank();
+        prompt.err("no kernel found.");
+        prompt.item("fix", "install the hkm-kernel package, or: hkm-config set-kernel-home <path>");
+        return 1;
+    };
+    prompt.item("kernel home", home);
+
+    // 2. Check kernel pieces.
+    const autoload = try std.fs.path.join(allocator, &.{ home, "vendor", "autoload.php" });
+    const projects = try std.fs.path.join(allocator, &.{ home, "projects", "projects.json" });
+    const have_vendor = util.fileExists(io, autoload);
+    const have_registry = util.fileExists(io, projects);
+    prompt.item("vendor/autoload.php", if (have_vendor) "present" else "MISSING");
+    prompt.item("projects registry", if (have_registry) "present" else "absent (no projects registered yet)");
+
+    // 3. Ensure HKM_KERNEL_HOME is persisted and current.
+    const saved = try userconfig.get(allocator, io, env, "HKM_KERNEL_HOME");
+    var wrote = false;
+    if (saved == null or !std.mem.eql(u8, saved.?, home)) {
+        try userconfig.set(allocator, io, env, "HKM_KERNEL_HOME", home);
+        wrote = true;
+    }
+
+    prompt.blank();
+    if (!have_vendor) {
+        prompt.warn("kernel dependencies are not installed.");
+        const installer = try std.fs.path.join(allocator, &.{ home, "install.sh" });
+        if (util.fileExists(io, installer)) {
+            prompt.item("run", try std.fmt.allocPrint(allocator, "sh {s}", .{installer}));
+        } else {
+            prompt.item("run", try std.fmt.allocPrint(allocator, "cd {s} && composer install --no-dev", .{home}));
+        }
+        return 1;
+    }
+
+    if (wrote) {
+        prompt.ok("configuration written — HKM_KERNEL_HOME pinned.");
+    } else {
+        prompt.ok("configuration is complete.");
+    }
+    prompt.muted("verify the runtime with: hkm doctor");
+    return 0;
 }

--- a/tools/src/lib/kernel.zig
+++ b/tools/src/lib/kernel.zig
@@ -65,6 +65,44 @@ pub fn findCliPath(allocator: std.mem.Allocator, io: Io, env: *EnvMap) ![]const 
     return (try resolve(allocator, io, env)).path;
 }
 
+/// A directory is a kernel root if it holds composer.json (true for both the
+/// dev monorepo and an installed /opt/hkm-kernel).
+fn isKernelRoot(io: Io, dir: []const u8) bool {
+    var buf: [4096]u8 = undefined;
+    const marker = std.fmt.bufPrint(&buf, "{s}/composer.json", .{dir}) catch return false;
+    return util.fileExists(io, marker);
+}
+
+/// Resolve the kernel ROOT directory (the folder holding composer.json, vendor/,
+/// projects/). Used by `run`, the registry, and `hkm-config`. Order:
+///   1. HKM_KERNEL_HOME
+///   2. self-located relative to THIS executable (installed .deb/.app/zip, or the
+///      dev monorepo when running repo/bin/hkm)
+///   3. /opt/hkm-kernel default
+/// Returns null when no kernel can be found.
+pub fn resolveHome(allocator: std.mem.Allocator, io: Io, env: *EnvMap) !?[]const u8 {
+    if (env.get("HKM_KERNEL_HOME")) |h| {
+        if (h.len > 0) return util.trimSlash(h);
+    }
+    if (std.process.executableDirPathAlloc(io, allocator)) |dir| {
+        // parent = the dir ABOVE the executable's dir (normalized, no "..").
+        const parent = std.fs.path.dirname(dir) orelse dir;
+        const rels = [_][]const []const u8{
+            &.{ parent, "Resources", "opt", "hkm-kernel" }, // macOS .app (MacOS→Contents)
+            &.{ dir, "hkm-kernel" }, // windows/portable zip
+            &.{ parent, "opt", "hkm-kernel" }, // portable
+            &.{ parent, "lib", "hkm-kernel" },
+            &.{parent}, // dev monorepo: repo/bin/hkm → repo root
+        };
+        for (rels) |parts| {
+            const cand = try std.fs.path.join(allocator, parts);
+            if (isKernelRoot(io, cand)) return cand;
+        }
+    } else |_| {}
+    if (isKernelRoot(io, "/opt/hkm-kernel")) return "/opt/hkm-kernel";
+    return null;
+}
+
 pub fn sourceLabel(s: Source) []const u8 {
     return switch (s) {
         .cli_path_env => "HKM_CLI_PATH override",

--- a/tools/src/lib/registry.zig
+++ b/tools/src/lib/registry.zig
@@ -7,6 +7,7 @@
 
 const std = @import("std");
 const util = @import("util.zig");
+const kernel = @import("kernel.zig");
 
 const Dir = std.Io.Dir;
 const Io = std.Io;
@@ -33,6 +34,13 @@ pub fn resolvePath(allocator: std.mem.Allocator, io: Io, env: *EnvMap) !?[]const
     }
     if (env.get("HKM_KERNEL_HOME")) |h| {
         if (h.len > 0) return try std.fmt.allocPrint(allocator, "{s}/projects/projects.json", .{trimSlash(h)});
+    }
+    // Self-locate the kernel relative to THIS executable (installed .deb/.app/zip
+    // or the dev monorepo). This is what makes `hkm run --pick` work on a packaged
+    // install with no env vars set — the registry lives at <kernel>/projects/.
+    if (try kernel.resolveHome(allocator, io, env)) |home| {
+        const p = try std.fmt.allocPrint(allocator, "{s}/projects/projects.json", .{home});
+        if (Dir.cwd().access(io, p, .{})) |_| return p else |_| {}
     }
     if (env.get("PWD")) |pwd| {
         if (pwd.len > 0) return findUpwards(allocator, io, pwd);

--- a/tools/src/lib/services.zig
+++ b/tools/src/lib/services.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 const registry = @import("registry.zig");
+const kernel = @import("kernel.zig");
 const util = @import("util.zig");
 
 const Dir = std.Io.Dir;
@@ -48,11 +49,12 @@ pub fn resolveAutoload(allocator: std.mem.Allocator, io: Io, env: *EnvMap) !?[]c
     if (env.get("HKM_GLOBAL_AUTOLOAD")) |v| {
         if (v.len > 0) return v;
     }
-    if (env.get("HKM_KERNEL_HOME")) |h| {
-        if (h.len > 0) {
-            const p = try std.fmt.allocPrint(allocator, "{s}/vendor/autoload.php", .{util.trimSlash(h)});
-            if (util.fileExists(io, p)) return p;
-        }
+    // Self-locate the kernel (HKM_KERNEL_HOME, then relative to this executable,
+    // then /opt/hkm-kernel) and use its vendor/autoload.php. This makes an
+    // installed launcher use the INSTALLED kernel — not a dev tree found via PWD.
+    if (try kernel.resolveHome(allocator, io, env)) |home| {
+        const p = try std.fmt.allocPrint(allocator, "{s}/vendor/autoload.php", .{home});
+        if (util.fileExists(io, p)) return p;
     }
     if (try registry.resolvePath(allocator, io, env)) |jsonPath| {
         if (util.parentOf(util.parentOf(jsonPath))) |kernel_root| {
@@ -71,15 +73,14 @@ pub fn resolveAutoload(allocator: std.mem.Allocator, io: Io, env: *EnvMap) !?[]c
 /// apply. Used to export HKM_KERNEL_HOME to child processes so a served app's
 /// runtime `getenv('HKM_KERNEL_HOME')` resolves.
 pub fn resolveKernelHome(allocator: std.mem.Allocator, io: Io, env: *EnvMap, autoload: ?[]const u8) !?[]const u8 {
-    if (env.get("HKM_KERNEL_HOME")) |h| {
-        if (h.len > 0) return util.trimSlash(h);
-    }
-    // <home>/vendor/autoload.php → <home>
+    // <home>/vendor/autoload.php → <home> (keeps home consistent with the autoload
+    // we already resolved).
     if (autoload) |a| {
         if (std.mem.endsWith(u8, a, "/vendor/autoload.php")) {
             if (util.parentOf(util.parentOf(a))) |home| return home;
         }
     }
+    if (try kernel.resolveHome(allocator, io, env)) |home| return home;
     if (try registry.resolvePath(allocator, io, env)) |jsonPath| {
         if (util.parentOf(util.parentOf(jsonPath))) |kernel_root| {
             if (util.dirExists(Dir.cwd(), io, kernel_root)) return kernel_root;

--- a/tools/src/lib/userconfig.zig
+++ b/tools/src/lib/userconfig.zig
@@ -1,0 +1,92 @@
+//! Persistent user config for the hkm launcher: `~/.config/hkm/config.env`.
+//!
+//! A tiny KEY=VALUE file (e.g. HKM_KERNEL_HOME=/opt/hkm-kernel). The launcher
+//! LOADS it into the environment at startup, so values written by `hkm-config`
+//! actually take effect for `hkm run`, the registry, and the PHP passthrough.
+//! REAL process-environment values always win (a shell export overrides the file).
+
+const std = @import("std");
+const Io = std.Io;
+const EnvMap = std.process.Environ.Map;
+const Dir = std.Io.Dir;
+
+/// Absolute path to the config file, honouring XDG_CONFIG_HOME then HOME.
+pub fn path(allocator: std.mem.Allocator, env: *EnvMap) !?[]const u8 {
+    if (env.get("XDG_CONFIG_HOME")) |x| {
+        if (x.len > 0) return try std.fmt.allocPrint(allocator, "{s}/hkm/config.env", .{x});
+    }
+    if (env.get("HOME")) |home| {
+        if (home.len > 0) return try std.fmt.allocPrint(allocator, "{s}/.config/hkm/config.env", .{home});
+    }
+    return null;
+}
+
+/// Load KEY=VALUE lines into `env`, WITHOUT overriding keys already set in the
+/// real environment. Silently no-ops if the file is absent. Best-effort.
+pub fn load(allocator: std.mem.Allocator, io: Io, env: *EnvMap) void {
+    const cfg = (path(allocator, env) catch return) orelse return;
+    const content = Dir.cwd().readFileAlloc(io, cfg, allocator, .limited(64 * 1024)) catch return;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        const eq = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+        const key = std.mem.trim(u8, line[0..eq], " \t");
+        const val = std.mem.trim(u8, line[eq + 1 ..], " \t");
+        if (key.len == 0) continue;
+        // Process env wins — only fill in what isn't already set.
+        if (env.get(key) != null) continue;
+        env.put(key, val) catch continue;
+    }
+}
+
+/// Read a single key from the config file (not the environment). Null if absent.
+pub fn get(allocator: std.mem.Allocator, io: Io, env: *EnvMap, key: []const u8) !?[]const u8 {
+    const cfg = (try path(allocator, env)) orelse return null;
+    const content = Dir.cwd().readFileAlloc(io, cfg, allocator, .limited(64 * 1024)) catch return null;
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        const eq = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+        if (std.mem.eql(u8, std.mem.trim(u8, line[0..eq], " \t"), key)) {
+            return try allocator.dupe(u8, std.mem.trim(u8, line[eq + 1 ..], " \t"));
+        }
+    }
+    return null;
+}
+
+/// Set (insert or replace) KEY=VALUE in the config file, preserving other keys.
+pub fn set(allocator: std.mem.Allocator, io: Io, env: *EnvMap, key: []const u8, value: []const u8) !void {
+    const cfg = (try path(allocator, env)) orelse return error.MissingHome;
+    if (std.fs.path.dirname(cfg)) |dir| try Dir.cwd().createDirPath(io, dir);
+
+    var out: std.ArrayList(u8) = .empty;
+    var replaced = false;
+
+    if (Dir.cwd().readFileAlloc(io, cfg, allocator, .limited(64 * 1024))) |content| {
+        var lines = std.mem.splitScalar(u8, content, '\n');
+        while (lines.next()) |raw| {
+            const line = std.mem.trim(u8, raw, "\r");
+            if (line.len == 0) continue;
+            const eq = std.mem.indexOfScalar(u8, line, '=');
+            if (eq != null and std.mem.eql(u8, std.mem.trim(u8, line[0..eq.?], " \t"), key)) {
+                try out.appendSlice(allocator, key);
+                try out.append(allocator, '=');
+                try out.appendSlice(allocator, value);
+                try out.append(allocator, '\n');
+                replaced = true;
+            } else {
+                try out.appendSlice(allocator, line);
+                try out.append(allocator, '\n');
+            }
+        }
+    } else |_| {}
+
+    if (!replaced) {
+        try out.appendSlice(allocator, key);
+        try out.append(allocator, '=');
+        try out.appendSlice(allocator, value);
+        try out.append(allocator, '\n');
+    }
+    try Dir.cwd().writeFile(io, .{ .sub_path = cfg, .data = out.items });
+}

--- a/tools/src/main.zig
+++ b/tools/src/main.zig
@@ -9,6 +9,7 @@ const cli_cmd = @import("commands/cli.zig");
 const doctor_cmd = @import("commands/doctor.zig");
 const upgrade_cmd = @import("commands/upgrade.zig");
 const kernel = @import("lib/kernel.zig");
+const userconfig = @import("lib/userconfig.zig");
 const banner = @import("lib/banner.zig");
 const prompt = @import("lib/prompt.zig");
 
@@ -68,6 +69,10 @@ pub fn main(init: std.process.Init.Minimal) !void {
     const io = threaded.io();
     var env_map = try init.environ.createMap(allocator);
     defer env_map.deinit();
+
+    // Load persistent config (~/.config/hkm/config.env) so values written by
+    // `hkm-config` take effect. Real environment variables always win.
+    userconfig.load(allocator, io, &env_map);
 
     const args = try init.args.toSlice(allocator);
 


### PR DESCRIPTION
Fixes the reported issues:
- `hkm run --pick` → 'Kernel registry not found' on packaged installs
- `hkm run .` silently using a dev kernel instead of the installed one
- `hkm-config` writing a config file nothing read

Now run/registry/hkm-config all self-locate the kernel relative to the launcher (installed `/opt/hkm-kernel` or the dev repo), the launcher loads `~/.config/hkm/config.env`, and `hkm-config` checks + repairs the config. No version bump (recorded under Unreleased).
