### PR TITLE
feat(userdata): HKM_USERDATA_DIR so updates don't clobber the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `HKM_USERDATA_DIR` — relocate the persistent registry (`projects.json` +
+  `platform.json`) outside the kernel install so a kernel update never
+  overwrites it. Honoured by the `hkm` CLI (registry) and the PHP
+  `DomainResolver`; falls back to `<kernel>/projects` when unset.
+- The `.deb` marks `projects.json` + `platform.json` as dpkg conffiles, so an
+  in-place upgrade preserves a user's registrations even without relocating.
+
 ## [1.0.3] - 2026-07-08
 
 ### Changed

--- a/projects/Bootstrap/Domain/DomainResolver.php
+++ b/projects/Bootstrap/Domain/DomainResolver.php
@@ -168,17 +168,36 @@ final class DomainResolver
     /**
      * @return array{adminSubs: list<string>, apiSubs: list<string>, projects: array<string, mixed>}
      */
+    /**
+     * Directory holding the persistent registry files (projects.json,
+     * platform.json). HKM_USERDATA_DIR relocates them outside the kernel so an
+     * update never clobbers them; falls back to <base>/projects for a checkout.
+     */
+    private static function userdataDir(string $base): string
+    {
+        $dir = $_SERVER['HKM_USERDATA_DIR']
+            ?? $_ENV['HKM_USERDATA_DIR']
+            ?? getenv('HKM_USERDATA_DIR')
+            ?: null;
+
+        return is_string($dir) && $dir !== '' ? rtrim($dir, '/') : $base . '/projects';
+    }
+
     private static function loadRegistries(string $base): array
     {
         if (isset(self::$cache[$base])) {
             return self::$cache[$base];
         }
 
-        $platform  = self::readJson($base . '/projects/platform.json');
+        // The registry files are USER DATA: they live in HKM_USERDATA_DIR when
+        // set (persistent, outside the kernel install so an update cannot
+        // overwrite them), else under <base>/projects for a dev checkout.
+        $userdata  = self::userdataDir($base);
+        $platform  = self::readJson($userdata . '/platform.json');
         $adminSubs = self::stringList($platform['subdomains']['admin'] ?? null) ?: ['app'];
         $apiSubs   = self::stringList($platform['subdomains']['api'] ?? null) ?: ['api'];
 
-        $projects = self::readJson($base . '/projects/projects.json');
+        $projects = self::readJson($userdata . '/projects.json');
 
         return self::$cache[$base] = [
             'adminSubs' => $adminSubs,

--- a/tools/bundle.sh
+++ b/tools/bundle.sh
@@ -128,6 +128,14 @@ Description: PhpServicePlatform (HKM) kernel and native launcher
  runtime matches this machine's PHP. Needs network access during install.
  Run 'hkm doctor' afterwards to verify PHP and required extensions.
 EOF
+  # conffiles: the project registry + platform map are USER DATA. Marking them as
+  # dpkg conffiles makes upgrades PRESERVE the user's versions instead of
+  # overwriting them with the packaged defaults. (Relocate entirely with
+  # HKM_USERDATA_DIR if you'd rather keep them outside /opt.)
+  cat > "$P/DEBIAN/conffiles" <<EOF
+/opt/${KERNEL_DIRNAME}/projects/projects.json
+/opt/${KERNEL_DIRNAME}/projects/platform.json
+EOF
   # postinst: build vendor/ on the target via the shipped install.sh helper.
   cat > "$P/DEBIAN/postinst" <<EOF
 #!/bin/sh

--- a/tools/src/lib/registry.zig
+++ b/tools/src/lib/registry.zig
@@ -29,6 +29,11 @@ pub const Entry = struct {
 ///   3. walk up from PWD for an existing `projects/projects.json` (dev: the
 ///      kernel monorepo root)
 pub fn resolvePath(allocator: std.mem.Allocator, io: Io, env: *EnvMap) !?[]const u8 {
+    // HKM_USERDATA_DIR holds the persistent registry (projects.json + platform.json)
+    // OUTSIDE the kernel install, so a kernel update never overwrites it.
+    if (env.get("HKM_USERDATA_DIR")) |d| {
+        if (d.len > 0) return try std.fmt.allocPrint(allocator, "{s}/projects.json", .{trimSlash(d)});
+    }
     if (env.get("PSP_PROJECTS_DIR")) |d| {
         if (d.len > 0) return try std.fmt.allocPrint(allocator, "{s}/projects.json", .{trimSlash(d)});
     }

--- a/tools/src/main.zig
+++ b/tools/src/main.zig
@@ -36,6 +36,7 @@ fn printHelp() void {
     prompt.item("HKM_PHP_BIN", "override php binary (default: php)");
     prompt.item("HKM_CLI_PATH", "override target php CLI script");
     prompt.item("HKM_GLOBAL_AUTOLOAD", "override global autoload path");
+    prompt.item("HKM_USERDATA_DIR", "persistent registry dir (projects.json + platform.json); survives updates");
     prompt.item("PSP_PROJECTS_DIR", "dir holding the kernel projects.json registry");
     prompt.item("HKM_KERNEL_HOME", "kernel root (registry at <root>/projects/projects.json)");
 


### PR DESCRIPTION
`projects/projects.json` and `projects/platform.json` are user data, but a kernel update (new .deb / re-extracted archive) currently overwrites them.

- **`HKM_USERDATA_DIR`** relocates both files outside the kernel install. Honoured by the `hkm` CLI registry (Zig) **and** the PHP `DomainResolver` at runtime; falls back to `<kernel>/projects` when unset.
- The **.deb marks both files as dpkg conffiles**, so an in-place `apt install` upgrade preserves the user's registrations even without relocating.

Verified: PHP + Zig both read from `HKM_USERDATA_DIR`; the .deb ships the conffiles list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable user data directory so registry files can live outside the kernel install and survive updates.
  * Documented a new environment variable for pointing the app and CLI to persistent registry data.

* **Bug Fixes**
  * Upgrades now preserve existing registry settings by treating key registry files as configuration files in package installs.
  * Improved fallback behavior to continue using the default project directory when no custom location is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->