### PR TITLE
security: harden scaffolding defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Scaffolded `.env` (which holds the generated `APP_KEY`) is now written
+  `chmod 600` (owner-only); `~/.config/hkm/config.env` too.
+- Debug output is force-disabled when `APP_ENV=production`, even if `APP_DEBUG`
+  was left `true` in a mis-set `.env` — production never leaks internals.
+- New projects ship an `app/public/.htaccess`: denies dotfiles (`.env`, `.git`),
+  disables directory listing, drops `X-Powered-By`, adds baseline security
+  headers, and routes through the single front controller.
+
 ### Added
 - `HKM_USERDATA_DIR` — relocate the persistent registry (`projects.json` +
   `platform.json`) outside the kernel install so a kernel update never

--- a/templates/app/public/.htaccess
+++ b/templates/app/public/.htaccess
@@ -1,0 +1,27 @@
+# Apache hardening + front-controller for app/public.
+# (Nginx users: set root to app/public and try_files $uri /index.php?$query_string;
+#  and `location ~ /\. { deny all; }`.)
+
+# Never serve dotfiles (.env, .git, …) even if the docroot is misconfigured.
+<FilesMatch "^\.">
+    Require all denied
+</FilesMatch>
+
+# Do not expose the PHP version.
+<IfModule mod_headers.c>
+    Header always unset X-Powered-By
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Frame-Options "SAMEORIGIN"
+    Header always set Referrer-Policy "strict-origin-when-cross-origin"
+</IfModule>
+
+# Disable directory listing.
+Options -Indexes
+
+# Route every request through the single front controller.
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^ index.php [L]
+</IfModule>

--- a/templates/app/public/index.php
+++ b/templates/app/public/index.php
@@ -56,7 +56,10 @@ try {
     // 4. Last-resort net for anything the kernel's own ErrorStage could not
     //    handle. In debug we surface the message; in production we never leak
     //    internals — just a generic 500.
-    $debug = filter_var($_ENV['APP_DEBUG'] ?? getenv('APP_DEBUG') ?: 'false', FILTER_VALIDATE_BOOL);
+    // Debug output is NEVER shown in production, even if APP_DEBUG was left true
+    // (defense-in-depth against leaking internals from a mis-set .env).
+    $isProd = (($_ENV['APP_ENV'] ?? getenv('APP_ENV') ?: 'production') === 'production');
+    $debug  = !$isProd && filter_var($_ENV['APP_DEBUG'] ?? getenv('APP_DEBUG') ?: 'false', FILTER_VALIDATE_BOOL);
     Response::json([
         'error' => [
             'code'    => 'kernel.unhandled',

--- a/templates/env.example
+++ b/templates/env.example
@@ -1,4 +1,7 @@
 # Application Environment
+# SECURITY: in production set APP_ENV=production and APP_DEBUG=false. Debug output
+# is force-disabled when APP_ENV=production regardless, but never ship secrets in a
+# world-readable .env — keep this file chmod 600 and OUTSIDE the web docroot.
 APP_ENV=local
 APP_DEBUG=true
 APP_NAME="{{PROJECT_NAME}}"

--- a/tools/src/commands/new.zig
+++ b/tools/src/commands/new.zig
@@ -55,6 +55,7 @@ const templates = [_]Template{
     .{ .dest = "app/bootstrap/kernel-autoload.php", .src = "app/bootstrap/kernel-autoload.php" },
     .{ .dest = "app/bootstrap/app.php", .src = "app/bootstrap/app.php" },
     .{ .dest = "app/public/index.php", .src = "app/public/index.php" },
+    .{ .dest = "app/public/.htaccess", .src = "app/public/.htaccess" },
     .{ .dest = "app/swoole/index.php", .src = "app/swoole/index.php" },
     .{ .dest = "app/cli/run.php", .src = "app/cli/run.php" },
     .{ .dest = "app/worker/run.php", .src = "app/worker/run.php" },
@@ -333,7 +334,11 @@ fn generateAppKey(allocator: std.mem.Allocator, io: Io, opts: Options) !void {
     }
 
     try Dir.cwd().writeFile(io, .{ .sub_path = env_path, .data = out.items });
-    prompt.ok("Generated APP_KEY in .env");
+
+    // The .env now holds the freshly generated APP_KEY (and will hold DB creds,
+    // JWT secrets, …). Lock it down to owner-only so it is never world-readable.
+    util.chmod600(io, env_path);
+    prompt.ok("Generated APP_KEY in .env (chmod 600)");
 }
 
 /// Run `composer install` inside the new project. Inherits stdio so the user

--- a/tools/src/lib/userconfig.zig
+++ b/tools/src/lib/userconfig.zig
@@ -89,4 +89,6 @@ pub fn set(allocator: std.mem.Allocator, io: Io, env: *EnvMap, key: []const u8, 
         try out.append(allocator, '\n');
     }
     try Dir.cwd().writeFile(io, .{ .sub_path = cfg, .data = out.items });
+    // Owner-only: this file may later hold overrides an operator considers private.
+    @import("util.zig").chmod600(io, cfg);
 }

--- a/tools/src/lib/util.zig
+++ b/tools/src/lib/util.zig
@@ -7,6 +7,15 @@ const Dir = std.Io.Dir;
 const Io = std.Io;
 const EnvMap = std.process.Environ.Map;
 
+/// Restrict a file to owner-only (chmod 0600). No-op on Windows. Best-effort —
+/// used for secret-bearing files like a project's .env.
+pub fn chmod600(io: Io, path: []const u8) void {
+    if (@import("builtin").os.tag == .windows) return;
+    const f = Dir.cwd().openFile(io, path, .{}) catch return;
+    defer f.close(io);
+    f.setPermissions(io, @enumFromInt(0o600)) catch {};
+}
+
 // ── path strings ────────────────────────────────────────────────────────────
 
 /// Trim trailing path separators (keeps a lone "/").


### PR DESCRIPTION
Fixes the concrete gaps from the security review:
- **`.env` chmod 600** — the freshly generated APP_KEY no longer sits in a world-readable file (also `config.env`).
- **Production never shows debug** — the entry point forces debug off when `APP_ENV=production` even if `APP_DEBUG=true` was left in a mis-set `.env`.
- **`app/public/.htaccess`** — denies dotfiles, disables listing, drops `X-Powered-By`, adds baseline security headers, front-controller rewrite.
- env.example documents production + secret handling.

History scan: no committed secrets. Verified: scaffolded .env is 600, .htaccess ships, prod debug gate present.