### PR TITLE
feat(scaffold): Apache vhost sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New projects also ship a full Apache virtual-host sample
+  (`app/apache.conf.example`) alongside the nginx one — DocumentRoot pinned to
+  `app/public`, dotfiles denied, only `index.php` executable, security headers.
+
 ## [1.0.4] - 2026-07-08
 
 ### Security

--- a/templates/app/apache.conf.example
+++ b/templates/app/apache.conf.example
@@ -1,0 +1,55 @@
+# Example Apache virtual host for a PhpServicePlatform project.
+# Copy to your Apache sites (e.g. /etc/apache2/sites-available/{{PROJECT_NAME}}.conf),
+# adjust ServerName / paths / PHP handler, then: a2ensite … && systemctl reload apache2
+# Per-directory rules also ship as app/public/.htaccess (used when AllowOverride is on).
+#
+# Requires: mod_rewrite, mod_headers  (a2enmod rewrite headers)
+
+<VirtualHost *:80>
+    ServerName example.com
+
+    # DocumentRoot is app/public ONLY — never the project root (keeps .env,
+    # config, src, vendor OUT of the web-served tree).
+    DocumentRoot /var/www/{{PROJECT_NAME}}/app/public
+
+    <Directory /var/www/{{PROJECT_NAME}}/app/public>
+        # Front-controller rewrite + hardening live in the shipped .htaccess.
+        # Set AllowOverride All to honour it, or inline those rules here and
+        # keep AllowOverride None for a small performance win.
+        AllowOverride All
+        Require all granted
+        Options -Indexes +FollowSymLinks
+    </Directory>
+
+    # Deny all dotfiles (.env, .git, .htaccess, …) anywhere under the vhost.
+    <DirectoryMatch "/\.">
+        Require all denied
+    </DirectoryMatch>
+
+    # Only index.php may be executed as PHP (defence against dropped scripts).
+    <FilesMatch "\.php$">
+        Require all denied
+    </FilesMatch>
+    <Files "index.php">
+        Require all granted
+    </Files>
+
+    # Environment for the app (match your deployment).
+    SetEnv APP_ENV production
+    # SetEnv HKM_USERDATA_DIR /var/lib/hkm
+
+    # Baseline security headers (SecurityFilters plugin also sets these at runtime).
+    <IfModule mod_headers.c>
+        Header always unset X-Powered-By
+        Header always set X-Content-Type-Options "nosniff"
+        Header always set X-Frame-Options "SAMEORIGIN"
+        Header always set Referrer-Policy "strict-origin-when-cross-origin"
+    </IfModule>
+    ServerTokens Prod
+    ServerSignature Off
+
+    LimitRequestBody 26214400
+
+    ErrorLog  ${APACHE_LOG_DIR}/{{PROJECT_NAME}}-error.log
+    CustomLog ${APACHE_LOG_DIR}/{{PROJECT_NAME}}-access.log combined
+</VirtualHost>

--- a/tools/src/commands/new.zig
+++ b/tools/src/commands/new.zig
@@ -57,6 +57,7 @@ const templates = [_]Template{
     .{ .dest = "app/public/index.php", .src = "app/public/index.php" },
     .{ .dest = "app/public/.htaccess", .src = "app/public/.htaccess" },
     .{ .dest = "app/nginx.conf.example", .src = "app/nginx.conf.example" },
+    .{ .dest = "app/apache.conf.example", .src = "app/apache.conf.example" },
     .{ .dest = "app/swoole/index.php", .src = "app/swoole/index.php" },
     .{ .dest = "app/cli/run.php", .src = "app/cli/run.php" },
     .{ .dest = "app/worker/run.php", .src = "app/worker/run.php" },


### PR DESCRIPTION
New projects now ship `app/apache.conf.example` next to the nginx one — DocumentRoot pinned to `app/public`, dotfiles denied, only index.php executable, baseline security headers. Verified: scaffolds (30 files), token-replaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New projects now include an Apache virtual-host sample alongside the existing nginx example.
  * The generated sample uses `app/public` as the web root and includes common security-oriented defaults such as blocking dotfiles, limiting executable PHP files, and setting basic headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->