### PR TITLE
chore(release): v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-07-08
+
 ### Added
 - New projects also ship a full Apache virtual-host sample
   (`app/apache.conf.example`) alongside the nginx one — DocumentRoot pinned to
@@ -115,7 +117,8 @@ macOS, and Windows, built and published automatically from a `v*` tag.
   (`phpunit.xml` is gitignored).
 - Windows cross-compilation: guarded POSIX-only raw-mode TTY code.
 
-[Unreleased]: https://github.com/AlfaCode-Team/php-service-platform/compare/v1.0.4...HEAD
+[Unreleased]: https://github.com/AlfaCode-Team/php-service-platform/compare/v1.0.5...HEAD
+[1.0.5]: https://github.com/AlfaCode-Team/php-service-platform/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/AlfaCode-Team/php-service-platform/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/AlfaCode-Team/php-service-platform/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/AlfaCode-Team/php-service-platform/compare/v1.0.1...v1.0.2


### PR DESCRIPTION
Ships the Apache vhost scaffolding sample.