### PR TITLE
release: v1.4.0 — hkm install: restore var/userdata/plugins after a git clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-08-28
+
+A project's `plugins/`, `var/*` and `userdata/storage/*` are gitignored on
+purpose — plugin source is fetched from its own git remote, and `var/`/
+`userdata/` are runtime state, not source. That leaves a project pulled onto a
+new machine (a teammate's clone, a fresh server, CI) missing all three, unable
+to boot until someone reconstructs them by hand.
+
+### Added
+- **`hkm install [path|name]`** — brings a cloned/pulled project up to a
+  runnable state in one command: registers it in the kernel registry;
+  recreates `var/logs`, `var/cache/manifests`, `var/tmp`, `var/locks`,
+  `var/sessions`, `var/queue` and `userdata/storage`; creates `.env` from
+  `.env.example` and generates `APP_KEY` if either is missing or empty (never
+  touches a key that is already set); runs `composer install`; then fetches
+  every plugin the project's own `app/bootstrap/app.php` wires — the same
+  fetch-and-lock step `hkm new` runs right after scaffolding, now shared via
+  `lib/plugin_provision.zig` instead of duplicated. Every step past directory
+  creation has a `--no-*` flag.
+- **`hkm install --production` / `--owner=<user>[:<group>]`** — correct
+  permissions AND ownership on a server, not just "writable". `--production`
+  tightens `var/`/`userdata/` to `0750`/`0640` (no "other" access) instead of
+  the dev defaults `0775`/`0664`; it deliberately does not guess an owner.
+  `--owner` recursively `chown`s both directories to the account your web
+  server / PHP-FPM pool actually runs as (`user`, `user:group` and `:group`
+  all work, passed straight through to the system `chown`) and reports a
+  failed chown per-directory rather than swallowing it — unlike chmod, a
+  production ownership fix that silently didn't happen is worse than one that
+  says so. `HKM_PROD_OWNER` sets a default so a deploy environment does not
+  have to repeat `--owner=` on every run.
+
 ## [1.3.3] - 2026-08-18
 
 Follows 1.3.2 within a day, and the theme is narrower: 1.3.2 fixed *which*

--- a/tools/docs/hkm-cli-usage.md
+++ b/tools/docs/hkm-cli-usage.md
@@ -20,6 +20,7 @@ hkm <command> --help        # detailed help for a command
 
 ```
 hkm new <path> [opts]        scaffold a new PhpServicePlatform project
+hkm install [path|name]      register a project, restore var/userdata/plugins after a git clone
 hkm run [path|name]          run a project locally (PHP dev server / Swoole)
 hkm cli [command]            run a project's console interactively
 hkm worker [args]            run a project's queue worker
@@ -59,6 +60,69 @@ hkm new ./scratch --no-register
 > On creation, hkm also **publishes the assets** (config, migrations, seeders,
 > factories, views) of every plugin the new project enables — copy only, no
 > migrations are run.
+
+---
+
+## hkm install — bring a cloned/pulled project up to a runnable state
+
+`plugins/`, `var/*` and `userdata/storage/*` are gitignored on purpose: plugin
+source is fetched from its own git remote, and `var/`/`userdata/` are runtime
+state, not source. That means a project pushed to git and pulled somewhere
+else — a teammate's machine, a fresh server, CI — is missing all three and
+will not boot. Run `hkm install` once, from inside the project, to fix that.
+
+```
+hkm install [path|name] [options]
+
+--no-register             skip kernel registry registration
+--no-key                   skip creating .env / generating APP_KEY
+--no-install               skip composer install
+--no-plugins               skip fetching the bootstrap's plugins
+--no-chmod                 skip fixing var/ and userdata/ mode bits
+--verify-plugins           run each plugin's own test suite while installing (slow)
+--production, --prod       tighter mode bits (dir 0750/file 0640, no world access)
+--owner=<user>[:<group>]   chown var/ and userdata/ to this user[:group] (needs root/sudo)
+```
+
+What it does, in order: registers the project in the kernel registry; recreates
+`var/logs`, `var/cache/manifests`, `var/tmp`, `var/locks`, `var/sessions`,
+`var/queue` and `userdata/storage` if missing; chmods `var/` and `userdata/`
+(and anything already inside them) writable; creates `.env` from `.env.example`
+and generates `APP_KEY` if either is missing or empty (never overwrites a real
+key); runs `composer install`; then fetches every plugin the project's own
+`app/bootstrap/app.php` wires, the same fetch-and-lock step `hkm new` runs
+right after scaffolding.
+
+### `--production` / `--owner` — correct permissions AND ownership on a server
+
+Dev mode chmods `var/`/`userdata/` to `0775`/`0664` (group-writable, world
+readable) and stops there — good enough when the files are already owned by
+whoever is running `hkm`. On a real server that is rarely the case: the web
+server / PHP-FPM pool usually runs as its own account (`www-data`, `nginx`,
+`app`, …), and CHMOD alone cannot fix that — only `chown` can.
+
+- `--production` swaps the mode bits for `0750`/`0640` (owner + group only, no
+  "other" access at all). It does **not** guess an owner — correctness matters
+  more than convenience here, and guessing wrong on a shared box is worse than
+  asking.
+- `--owner=<user>[:<group>]` recursively `chown`s `var/` and `userdata/` to
+  that account. It is passed straight through to the system `chown`, so
+  `www-data`, `www-data:www-data` and `:www-data` (group only) all work.
+  Requires root/sudo unless the process already owns the target files — a
+  failed chown is reported per-directory, never swallowed silently.
+- Set `HKM_PROD_OWNER` once in your deploy environment to avoid repeating
+  `--owner=` on every run; an explicit `--owner=` flag always wins.
+- `--production` with no `--owner` (and no `HKM_PROD_OWNER`) still tightens the
+  mode bits, but warns that ownership was left unchanged instead of guessing.
+
+```bash
+cd my-shop && hkm install       # after a fresh git clone
+hkm install ./my-shop
+hkm install shop                # by registered name
+hkm install --no-install        # vendor/ already cached — skip composer
+sudo hkm install --production --owner=www-data:www-data   # on a server
+HKM_PROD_OWNER=www-data:www-data sudo hkm install --production
+```
 
 ---
 

--- a/tools/src/commands/install.zig
+++ b/tools/src/commands/install.zig
@@ -1,0 +1,550 @@
+//! `hkm install [path|name]` — bring a project that was just `git clone`d /
+//! `git pull`ed up to a runnable state.
+//!
+//! A project's `plugins/`, `var/*` and `userdata/storage/*` are gitignored on
+//! purpose (see the scaffolded `.gitignore`): plugin source is fetched from its
+//! own git remote by `hkm plugins install`, and `var/`/`userdata/` are runtime
+//! state, not source. That means a project pushed to git and pulled somewhere
+//! else — a teammate's machine, a fresh server, a CI runner — is missing all
+//! three and will not boot. `install` is the one command that restores them:
+//!
+//!   1. register the project in the kernel's projects.json registry
+//!   2. recreate the runtime directories a boot expects to find
+//!   3. fix their permissions (writable — a stale root-owned dir from a
+//!      previous container run is a common reason a fresh clone can't boot)
+//!   4. create .env from .env.example and generate APP_KEY if either is missing
+//!   5. `composer install`
+//!   6. fetch every plugin the project's own bootstrap wires (mirrors what
+//!      `hkm new` does right after scaffolding — see lib/plugin_provision.zig)
+//!
+//! Every step besides directory creation can be skipped with a --no-* flag, for
+//! a CI image that already provisions one of them another way.
+//!
+//!   hkm install                  # install the project in the current directory
+//!   hkm install ./my-shop        # install a specific path
+//!   hkm install shop             # install a registered project by name
+//!   hkm install --no-install     # skip composer install (e.g. vendor/ is cached)
+
+const std = @import("std");
+const registry = @import("../lib/registry.zig");
+const prompt = @import("../lib/prompt.zig");
+const util = @import("../lib/util.zig");
+const services = @import("../lib/services.zig");
+const plugin_assets = @import("../lib/plugin_assets.zig");
+const plugin_provision = @import("../lib/plugin_provision.zig");
+const plugins_cmd = @import("plugins.zig");
+
+const Dir = std.Io.Dir;
+const Io = std.Io;
+const EnvMap = std.process.Environ.Map;
+
+/// Gitignored runtime directories a boot expects to find. Mirrors what
+/// `hkm new` scaffolds and `hkm discover` restores — kept as its own copy here
+/// (matching the existing precedent between those two commands) rather than a
+/// shared constant, since the two already disagree on the full scaffold list.
+const runtime_dirs = [_][]const u8{
+    "var/logs",
+    "var/cache/manifests",
+    "var/tmp",
+    "var/locks",
+    "var/sessions",
+    "var/queue",
+    "userdata/storage",
+};
+
+const Options = struct {
+    /// A project PATH (dir holding proj.json) OR a registered NAME. "" = cwd.
+    target: []const u8 = "",
+    register: bool = true,
+    key: bool = true,
+    /// composer install
+    install: bool = true,
+    /// fetch the plugins the project's bootstrap wires
+    plugins: bool = true,
+    /// fix var/ and userdata/ mode bits
+    chmod: bool = true,
+    verify_plugins: bool = false,
+    help: bool = false,
+    /// --production: var/ and userdata/ get tighter mode bits (dir 0750, file
+    /// 0640 — no "other" access) instead of the dev defaults (dir 0775, file
+    /// 0664), and a chown failure (see `owner`) is reported per-path instead
+    /// of only implied by "no --owner given".
+    production: bool = false,
+    /// --owner=<user>[:<group>] (also HKM_PROD_OWNER) — chown var/ and
+    /// userdata/ to this user[:group], typically the account your web server
+    /// / PHP-FPM pool actually runs as. Passed straight to the system `chown`,
+    /// so `user`, `user:group` and `:group` (group-only) all work. Requires
+    /// root/sudo unless the process already owns the target files. Applies
+    /// whenever set, independent of --production and of --no-chmod.
+    owner: ?[]const u8 = null,
+};
+
+fn parse(args: []const []const u8) ?Options {
+    var o = Options{};
+    var i: usize = 2;
+    while (i < args.len) : (i += 1) {
+        const a = args[i];
+        if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
+            o.help = true;
+        } else if (std.mem.eql(u8, a, "--no-register")) {
+            o.register = false;
+        } else if (std.mem.eql(u8, a, "--no-key")) {
+            o.key = false;
+        } else if (std.mem.eql(u8, a, "--no-install")) {
+            o.install = false;
+        } else if (std.mem.eql(u8, a, "--no-plugins")) {
+            o.plugins = false;
+        } else if (std.mem.eql(u8, a, "--no-chmod")) {
+            o.chmod = false;
+        } else if (std.mem.eql(u8, a, "--verify-plugins")) {
+            o.verify_plugins = true;
+        } else if (std.mem.eql(u8, a, "--production") or std.mem.eql(u8, a, "--prod")) {
+            o.production = true;
+        } else if (std.mem.startsWith(u8, a, "--owner=")) {
+            o.owner = a["--owner=".len..];
+        } else if (std.mem.eql(u8, a, "--owner")) {
+            if (i + 1 >= args.len) return null;
+            i += 1;
+            o.owner = args[i];
+        } else if (std.mem.startsWith(u8, a, "--")) {
+            // unknown flag — ignore so future flags don't hard-fail. Nothing
+            // this command does is destructive enough to warrant rejecting one
+            // the way `uninstall` does (see util.unknownFlag).
+            continue;
+        } else if (o.target.len == 0) {
+            o.target = a;
+        }
+    }
+    return o;
+}
+
+fn printHelp() void {
+    prompt.intro("hkm install — bring a cloned/pulled project up to a runnable state");
+    prompt.section("Usage");
+    prompt.item("hkm install", "install the project in the current directory");
+    prompt.item("hkm install <path|name>", "install a specific project or registered name");
+    prompt.blank();
+    prompt.section("What it does");
+    prompt.muted("Registers the project, restores the gitignored var/ and userdata/ runtime");
+    prompt.muted("directories with writable permissions, runs composer install, and fetches");
+    prompt.muted("every plugin the project's bootstrap wires (plugins/ is never committed).");
+    prompt.blank();
+    prompt.section("Options");
+    prompt.item("--no-register", "skip kernel registry registration");
+    prompt.item("--no-key", "skip creating .env / generating APP_KEY");
+    prompt.item("--no-install", "skip composer install");
+    prompt.item("--no-plugins", "skip fetching the bootstrap's plugins");
+    prompt.item("--no-chmod", "skip fixing var/ and userdata/ mode bits");
+    prompt.item("--verify-plugins", "run each plugin's own test suite while installing (slow)");
+    prompt.item("--production, --prod", "tighter mode bits (dir 0750/file 0640, no world access)");
+    prompt.item("--owner=<user>[:<group>]", "chown var/ and userdata/ to this user[:group] (needs root/sudo)");
+    prompt.item("--help, -h", "show this help");
+    prompt.blank();
+    prompt.section("Environment");
+    prompt.item("HKM_PROD_OWNER", "default --owner when it is not passed explicitly");
+    prompt.item("HKM_CHOWN_BIN", "override the chown binary (default: chown)");
+    prompt.blank();
+    prompt.section("Examples");
+    prompt.note("cd my-shop && hkm install");
+    prompt.note("hkm install --production --owner=www-data:www-data");
+    prompt.outro("Run this once after `git clone` / `git pull` on a machine new to the project");
+}
+
+pub fn run(allocator: std.mem.Allocator, io: Io, env: *EnvMap, args: []const []const u8) !u8 {
+    var opts = parse(args) orelse {
+        prompt.err("--owner needs a value.");
+        printHelp();
+        return 2;
+    };
+    if (opts.help) {
+        printHelp();
+        return 0;
+    }
+
+    // Fall back to HKM_PROD_OWNER so a deploy environment can set it once
+    // instead of repeating --owner=user:group on every `hkm install` call.
+    if (opts.owner == null) {
+        if (env.get("HKM_PROD_OWNER")) |v| {
+            if (v.len > 0) opts.owner = v;
+        }
+    }
+
+    const root = (try services.resolveRoot(allocator, io, env, opts.target)) orelse {
+        prompt.err(try std.fmt.allocPrint(
+            allocator,
+            "'{s}' is neither a project folder (with proj.json) nor a registered name.",
+            .{if (opts.target.len == 0) "." else opts.target},
+        ));
+        return 1;
+    };
+
+    const manifest = try readManifest(allocator, io, root);
+    prompt.intro(try std.fmt.allocPrint(allocator, "Install project '{s}'", .{manifest.name}));
+    prompt.muted(root);
+
+    // 1. register the project in the kernel registry.
+    if (opts.register) {
+        try registerProject(allocator, io, env, root, manifest);
+    }
+
+    // 2. recreate the gitignored runtime directories.
+    const created = try ensureRuntimeDirs(allocator, io, root);
+    if (created > 0) {
+        prompt.ok(try std.fmt.allocPrint(allocator, "Restored {d} runtime director{s}", .{
+            created,
+            if (created == 1) @as([]const u8, "y") else "ies",
+        }));
+    } else {
+        prompt.muted("Runtime directories already present");
+    }
+
+    // 3. make sure they (and anything already inside them) are writable, and
+    //    — in --production, or whenever --owner/HKM_PROD_OWNER is set — owned
+    //    by the right user[:group] (typically the web server's own account).
+    if (opts.chmod) {
+        fixPermissions(allocator, io, root, opts.production);
+        prompt.ok(if (opts.production)
+            "var/ and userdata/ set to production-safe permissions (0750/0640)"
+        else
+            "var/ and userdata/ set to writable permissions");
+    }
+    if (opts.owner) |owner| {
+        if (owner.len > 0) fixOwnership(allocator, io, env, root, owner);
+    } else if (opts.production) {
+        prompt.warn("--production: no --owner given (and HKM_PROD_OWNER is unset) — ownership of var/ and userdata/ left unchanged.");
+        prompt.muted("pass --owner=<user>[:<group>] — typically your web server's account, e.g. www-data:www-data.");
+    }
+
+    // 4. .env — create from .env.example if absent, generate APP_KEY if empty.
+    if (opts.key) {
+        try ensureEnv(allocator, io, root);
+    }
+
+    // 5. composer install — pulls the kernel + vendor deps.
+    if (opts.install) {
+        try composerInstall(allocator, io, env, root);
+    }
+
+    // 6. fetch every plugin the project's own bootstrap wires, then wire their
+    //    Support/helpers.php requires and publish their assets — same sequence
+    //    `hkm new` runs right after scaffolding.
+    var plugins_missing: usize = 0;
+    if (opts.plugins) {
+        plugins_missing = plugin_provision.installEnabled(allocator, io, env, root, .{
+            .verify = opts.verify_plugins,
+        }) catch blk: {
+            prompt.warn("Could not install the bootstrap's plugins — run 'hkm plugins install <name>' later.");
+            break :blk 1;
+        };
+
+        _ = plugins_cmd.healSupportRequires(allocator, io, env, root, false) catch 0;
+
+        plugin_assets.publishEnabled(allocator, io, env, root) catch {
+            prompt.warn("Could not publish plugin assets — run 'hkm plugins enable <p>' later.");
+        };
+    }
+
+    prompt.note("");
+    prompt.note("Next steps:");
+    if (plugins_missing > 0) {
+        prompt.muted("  # install the missing plugins listed above first");
+    } else {
+        prompt.muted("  hkm run                       # or: php -S localhost:8000 -t app/public");
+    }
+
+    if (plugins_missing > 0) {
+        prompt.outro(try std.fmt.allocPrint(
+            allocator,
+            "'{s}' installed — but {d} plugin(s) are missing, so it will not boot yet",
+            .{ manifest.name, plugins_missing },
+        ));
+        return 1;
+    }
+
+    prompt.outro(try std.fmt.allocPrint(allocator, "'{s}' is ready", .{manifest.name}));
+    return 0;
+}
+
+// --------------------------------------------------------------------------
+// proj.json
+// --------------------------------------------------------------------------
+
+const Manifest = struct {
+    name: []const u8,
+    version: []const u8,
+    domains: []const []const u8,
+};
+
+/// Read `<root>/proj.json` for the registry fields. `root` is already known to
+/// hold a proj.json (services.resolveRoot only returns paths that do), so a
+/// parse failure here means malformed JSON, not a missing file — fall back to
+/// the directory's own name rather than failing the whole command over it.
+fn readManifest(allocator: std.mem.Allocator, io: Io, root: []const u8) !Manifest {
+    const fallback = Manifest{ .name = basename(root), .version = "1.0.0", .domains = &.{} };
+
+    const path = try util.join(allocator, root, "proj.json");
+    const content = Dir.cwd().readFileAlloc(io, path, allocator, .limited(4 * 1024 * 1024)) catch return fallback;
+    const parsed = std.json.parseFromSliceLeaky(std.json.Value, allocator, content, .{}) catch return fallback;
+    if (parsed != .object) return fallback;
+
+    var domains: std.ArrayList([]const u8) = .empty;
+    if (parsed.object.get("domains")) |d| {
+        if (d == .array) {
+            for (d.array.items) |item| {
+                if (item == .string) try domains.append(allocator, item.string);
+            }
+        }
+    }
+
+    return .{
+        .name = strField(parsed.object, "name") orelse fallback.name,
+        .version = strField(parsed.object, "version") orelse fallback.version,
+        .domains = try domains.toOwnedSlice(allocator),
+    };
+}
+
+fn strField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const v = obj.get(key) orelse return null;
+    return if (v == .string) v.string else null;
+}
+
+/// Last path component of a (possibly trailing-slash) path.
+fn basename(path: []const u8) []const u8 {
+    var end = path.len;
+    while (end > 0 and (path[end - 1] == '/' or path[end - 1] == '\\')) end -= 1;
+    var start = end;
+    while (start > 0 and path[start - 1] != '/' and path[start - 1] != '\\') start -= 1;
+    return path[start..end];
+}
+
+// --------------------------------------------------------------------------
+// registry
+// --------------------------------------------------------------------------
+
+fn registerProject(allocator: std.mem.Allocator, io: Io, env: *EnvMap, root: []const u8, m: Manifest) !void {
+    const jsonPath = (try registry.resolvePath(allocator, io, env)) orelse {
+        prompt.warn("Kernel registry not found — skipping registration.");
+        prompt.muted("set PSP_PROJECTS_DIR or HKM_KERNEL_HOME, or run `hkm update` later.");
+        return;
+    };
+
+    try registry.upsert(allocator, io, jsonPath, .{
+        .name = m.name,
+        .version = m.version,
+        .path = root,
+        .domains = m.domains,
+    });
+
+    prompt.ok(try std.fmt.allocPrint(allocator, "Registered in {s}", .{jsonPath}));
+}
+
+// --------------------------------------------------------------------------
+// runtime directories + permissions
+// --------------------------------------------------------------------------
+
+/// Create every missing runtime directory under `root`. Uses createDirPath so
+/// parent segments (e.g. var/cache) are made too. Returns how many were absent.
+fn ensureRuntimeDirs(allocator: std.mem.Allocator, io: Io, root: []const u8) !usize {
+    const cwd = Dir.cwd();
+    var created: usize = 0;
+    for (runtime_dirs) |sub| {
+        const path = try util.join(allocator, root, sub);
+        if (util.dirExists(cwd, io, path)) continue;
+        try cwd.createDirPath(io, path);
+        created += 1;
+    }
+    return created;
+}
+
+/// Make var/ and userdata/ (and everything already inside them) writable.
+/// Best-effort — a mount this process cannot chmod is skipped, not fatal.
+/// `production` swaps the dev-friendly 0775/0664 for tighter 0750/0640 (no
+/// "other" access) — correct ownership (see fixOwnership) is what actually
+/// grants the web server access, so removing world access does not break it.
+fn fixPermissions(allocator: std.mem.Allocator, io: Io, root: []const u8, production: bool) void {
+    const dir_mode: u32 = if (production) 0o750 else 0o775;
+    const file_mode: u32 = if (production) 0o640 else 0o664;
+    for ([_][]const u8{ "var", "userdata" }) |sub| {
+        const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, sub }) catch continue;
+        if (!util.dirExists(Dir.cwd(), io, path)) continue;
+        util.chmodTreeWritable(allocator, io, path, dir_mode, file_mode, 8);
+    }
+}
+
+// --------------------------------------------------------------------------
+// ownership
+// --------------------------------------------------------------------------
+
+/// chown var/ and userdata/ (recursively) to `owner`, reporting each path's
+/// outcome explicitly — unlike chmod, a failed chown in production (wrong
+/// privileges, a typo'd user/group) is exactly the kind of thing that should
+/// NOT fail silently: the web server would still be unable to write.
+fn fixOwnership(allocator: std.mem.Allocator, io: Io, env: *EnvMap, root: []const u8, owner: []const u8) void {
+    if (@import("builtin").os.tag == .windows) {
+        prompt.warn("--owner is not supported on Windows — skipped.");
+        return;
+    }
+
+    var ok: usize = 0;
+    var total: usize = 0;
+    for ([_][]const u8{ "var", "userdata" }) |sub| {
+        const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, sub }) catch continue;
+        if (!util.dirExists(Dir.cwd(), io, path)) continue;
+        total += 1;
+        if (chownPath(io, env, path, owner)) {
+            ok += 1;
+        } else {
+            prompt.warn(std.fmt.allocPrint(
+                allocator,
+                "chown {s} {s} failed — needs root/sudo, or that user/group doesn't exist.",
+                .{ owner, sub },
+            ) catch "chown failed — needs root/sudo, or that user/group doesn't exist.");
+        }
+    }
+
+    if (total > 0 and ok == total) {
+        prompt.ok(std.fmt.allocPrint(allocator, "var/ and userdata/ owned by {s}", .{owner}) catch "var/ and userdata/ ownership fixed");
+    }
+}
+
+/// `chown -R <owner> <path>`. Shells out rather than resolving the user/group
+/// name to a uid/gid natively — the OS's own NSS already knows how to do that
+/// correctly (files, LDAP, whatever `/etc/nsswitch.conf` says), and `chown`
+/// already accepts `user`, `user:group` and `:group` (group-only) verbatim, so
+/// passing `owner` straight through keeps that flexibility for free. Returns
+/// whether the process exited 0.
+fn chownPath(io: Io, env: *EnvMap, path: []const u8, owner: []const u8) bool {
+    const chown_bin = env.get("HKM_CHOWN_BIN") orelse "chown";
+    var child = std.process.spawn(io, .{
+        .argv = &.{ chown_bin, "-R", owner, path },
+        .environ_map = env,
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .inherit,
+    }) catch return false;
+
+    const term = child.wait(io) catch return false;
+    return switch (term) {
+        .exited => |code| code == 0,
+        else => false,
+    };
+}
+
+// --------------------------------------------------------------------------
+// .env / APP_KEY
+// --------------------------------------------------------------------------
+
+/// Ensure `.env` exists (copied from `.env.example` if absent) and carries a
+/// non-empty APP_KEY, generating one only when the line is present and empty —
+/// never overwriting a real secret a developer (or an earlier `hkm install`)
+/// already set.
+fn ensureEnv(allocator: std.mem.Allocator, io: Io, root: []const u8) !void {
+    const cwd = Dir.cwd();
+    const env_path = try util.join(allocator, root, ".env");
+
+    if (!util.fileExists(io, env_path)) {
+        const example_path = try util.join(allocator, root, ".env.example");
+        const example = cwd.readFileAlloc(io, example_path, allocator, .limited(1024 * 1024)) catch {
+            prompt.warn("No .env and no .env.example — skipped.");
+            return;
+        };
+        try cwd.writeFile(io, .{ .sub_path = env_path, .data = example });
+        prompt.ok("Created .env from .env.example");
+    }
+
+    const content = cwd.readFileAlloc(io, env_path, allocator, .limited(1024 * 1024)) catch {
+        prompt.warn("Could not read .env — APP_KEY not checked.");
+        return;
+    };
+
+    if (hasNonEmptyAppKey(content)) {
+        util.chmod600(io, env_path);
+        return;
+    }
+
+    var raw: [32]u8 = undefined;
+    io.random(&raw);
+    const Enc = std.base64.standard.Encoder;
+    const key = try allocator.alloc(u8, Enc.calcSize(raw.len));
+    _ = Enc.encode(key, &raw);
+
+    var out: std.ArrayList(u8) = .empty;
+    var replaced = false;
+    var it = std.mem.splitScalar(u8, content, '\n');
+    var first = true;
+    while (it.next()) |line| {
+        if (!first) try out.append(allocator, '\n');
+        first = false;
+        if (!replaced and std.mem.startsWith(u8, line, "APP_KEY=")) {
+            try out.appendSlice(allocator, "APP_KEY=");
+            try out.appendSlice(allocator, key);
+            replaced = true;
+        } else {
+            try out.appendSlice(allocator, line);
+        }
+    }
+
+    if (!replaced) {
+        prompt.warn("No APP_KEY= line in .env — left unchanged.");
+        util.chmod600(io, env_path);
+        return;
+    }
+
+    try cwd.writeFile(io, .{ .sub_path = env_path, .data = out.items });
+    util.chmod600(io, env_path);
+    prompt.ok("Generated APP_KEY in .env (chmod 600)");
+}
+
+/// True when .env already has a non-blank `APP_KEY=` value.
+fn hasNonEmptyAppKey(content: []const u8) bool {
+    var it = std.mem.splitScalar(u8, content, '\n');
+    while (it.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        if (std.mem.startsWith(u8, line, "APP_KEY=")) {
+            return line.len > "APP_KEY=".len;
+        }
+    }
+    return false;
+}
+
+// --------------------------------------------------------------------------
+// composer
+// --------------------------------------------------------------------------
+
+/// Run `composer install` inside the project. Inherits stdio so the user sees
+/// progress; a missing/failing composer is a warning, not a hard error — the
+/// rest of `install` (registry, dirs, permissions, plugins) still has value on
+/// its own.
+fn composerInstall(allocator: std.mem.Allocator, io: Io, env: *EnvMap, root: []const u8) !void {
+    const composer = env.get("HKM_COMPOSER_BIN") orelse "composer";
+    prompt.note("");
+    prompt.ok("Running composer install…");
+
+    var child = std.process.spawn(io, .{
+        .argv = &.{ composer, "install", "--no-interaction" },
+        .environ_map = env,
+        .cwd = .{ .path = root },
+        .stdin = .inherit,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    }) catch {
+        prompt.warn("composer not found — skipped. Run `composer install` yourself.");
+        prompt.muted("(override the binary with HKM_COMPOSER_BIN)");
+        return;
+    };
+
+    const term = child.wait(io) catch {
+        prompt.warn("composer install did not complete cleanly.");
+        return;
+    };
+    switch (term) {
+        .exited => |code| {
+            if (code == 0) {
+                prompt.ok("Dependencies installed");
+            } else {
+                prompt.warn(try std.fmt.allocPrint(allocator, "composer install exited with code {d}.", .{code}));
+            }
+        },
+        else => prompt.warn("composer install was interrupted."),
+    }
+}

--- a/tools/src/commands/new.zig
+++ b/tools/src/commands/new.zig
@@ -31,9 +31,7 @@ const util = @import("../lib/util.zig");
 const services = @import("../lib/services.zig");
 const plugin_assets = @import("../lib/plugin_assets.zig");
 const plugins_cmd = @import("plugins.zig");
-const plugin_boot = @import("../lib/plugin_bootstrap.zig");
-const installer = @import("../lib/plugin_install.zig");
-const lockfile = @import("../lib/plugin_lock.zig");
+const plugin_provision = @import("../lib/plugin_provision.zig");
 
 const Dir = std.Io.Dir;
 const Io = std.Io;
@@ -331,7 +329,9 @@ pub fn run(allocator: std.mem.Allocator, io: Io, env: *EnvMap, args: []const []c
     // from git here, which is the same path `hkm plugins install` uses.
     var plugins_missing: usize = 0;
     if (opts.install) {
-        plugins_missing = installBootstrapPlugins(allocator, io, env, opts) catch blk: {
+        plugins_missing = plugin_provision.installEnabled(allocator, io, env, opts.path, .{
+            .verify = opts.verify_plugins,
+        }) catch blk: {
             prompt.warn("Could not install the bootstrap's plugins — run 'hkm plugins install <name>' later.");
             break :blk 1;
         };
@@ -582,105 +582,6 @@ fn domainsJson(allocator: std.mem.Allocator, domains: []const []const u8) ![]con
     return out.toOwnedSlice(allocator);
 }
 
-/// Install every plugin the scaffolded bootstrap enables.
-///
-/// Reads app/bootstrap/app.php rather than a hard-coded list, so the set can
-/// never drift from what the template actually wires — a list here that fell
-/// behind the template would reproduce exactly the missing-class failure this
-/// exists to prevent.
-/// Returns the number of plugins that could NOT be installed.
-/// Record an installed plugin in plugins.lock.json, naming it if that fails.
-///
-/// The install itself succeeded, so this is not fatal — but a silent failure
-/// leaves the lock disagreeing with what is on disk, and the user with no idea
-/// which plugin to re-add.
-fn recordOrWarn(
-    allocator: std.mem.Allocator,
-    io: Io,
-    projectRoot: []const u8,
-    name: []const u8,
-    entry: lockfile.Entry,
-) void {
-    installer.recordInLock(allocator, io, projectRoot, entry) catch {
-        const msg = std.fmt.allocPrint(
-            allocator,
-            "{s}: installed, but could not be recorded in plugins.lock.json — run `hkm plugins add {s}` to repair the lock.",
-            .{ name, name },
-        ) catch return;
-        prompt.warn(msg);
-    };
-}
-
-fn installBootstrapPlugins(allocator: std.mem.Allocator, io: Io, env: *EnvMap, opts: Options) !usize {
-    const bootstrap = try util.join(allocator, opts.path, "app/bootstrap/app.php");
-    const source = Dir.cwd().readFileAlloc(io, bootstrap, allocator, .limited(4 * 1024 * 1024)) catch return 0;
-
-    var aliases: std.ArrayList(plugin_boot.Alias) = .empty;
-    try plugin_boot.collectAliases(allocator, source, &aliases);
-
-    var enabled: std.ArrayList(plugin_boot.Enabled) = .empty;
-    try plugin_boot.collectEnabled(allocator, source, aliases.items, &enabled);
-
-    if (enabled.items.len == 0) return 0;
-
-    prompt.section("Installing plugins");
-
-    var ok: usize = 0;
-    // Names, not just a count: the message that follows is the only place the
-    // user learns WHICH plugins are missing, and "3 of 19 failed" leaves them
-    // diffing the bootstrap against plugins/ to find out.
-    var failed: std.ArrayList([]const u8) = .empty;
-    for (enabled.items) |e| {
-        const outcome = installer.install(allocator, io, env, opts.path, e.name, .{
-            .interactive = false,
-            // Scaffolding installs ~19 pinned, already-released plugins. Running
-            // each one's suite means a composer install plus a phpunit run per
-            // plugin — tens of minutes, for versions that were tested when they
-            // were released. Verification stays the default for a deliberate
-            // single install, where it is worth the wait; here it is opt-in.
-            .verify = opts.verify_plugins,
-        }) catch {
-            try failed.append(allocator, e.name);
-            continue;
-        };
-        switch (outcome) {
-            .refused => |why| {
-                try failed.append(allocator, e.name);
-                prompt.warn(why);
-            },
-            .installed, .up_to_date, .linked, .updated => {
-                ok += 1;
-                _ = installer.report(allocator, e.name, outcome, false) catch {};
-                // A lockfile write that fails is NOT a successful install:
-                // swallowing it left the command reporting success while
-                // plugins.lock.json did not record the plugin, so the next
-                // `hkm plugins` run cannot tell it is already there.
-                switch (outcome) {
-                    .installed, .up_to_date, .linked => |entry| recordOrWarn(allocator, io, opts.path, e.name, entry),
-                    .updated => |u| recordOrWarn(allocator, io, opts.path, e.name, u.to),
-                    .refused => {},
-                }
-            },
-        }
-    }
-
-    if (failed.items.len > 0) {
-        prompt.warn(try std.fmt.allocPrint(
-            allocator,
-            "{d} of {d} plugin(s) could not be installed — the project will not boot until they are:",
-            .{ failed.items.len, enabled.items.len },
-        ));
-        // One command per plugin, and no separate list of bare names above it:
-        // the commands already name every one, and printing both meant reading
-        // the same nineteen names twice. `install` takes a SINGLE plugin — its
-        // second positional is the project path, so space-joining the names
-        // would install the first and treat the rest as a directory.
-        for (failed.items) |name| {
-            prompt.muted(try std.fmt.allocPrint(allocator, "  hkm plugins install {s}", .{name}));
-        }
-    } else {
-        prompt.ok(try std.fmt.allocPrint(allocator, "{d} plugin(s) installed", .{ok}));
-    }
-
-    return failed.items.len;
-}
+// Bootstrap plugin installation now lives in lib/plugin_provision.zig — shared
+// with `hkm install`, which needs the identical fetch-and-lock behaviour for
+// an existing project whose gitignored plugins/ did not travel with git.

--- a/tools/src/lib/plugin_provision.zig
+++ b/tools/src/lib/plugin_provision.zig
@@ -1,0 +1,119 @@
+//! Install every plugin a project's own `app/bootstrap/app.php` wires.
+//!
+//! Reads the bootstrap rather than taking an explicit list, so the set
+//! installed can never drift from what the template/project actually enables.
+//! Shared by `hkm new` (a freshly scaffolded project) and `hkm install` (an
+//! existing project whose gitignored `plugins/` did not travel with a git
+//! clone) — both need the identical fetch-and-lock behaviour.
+
+const std = @import("std");
+const prompt = @import("prompt.zig");
+const util = @import("util.zig");
+const installer = @import("plugin_install.zig");
+const lockfile = @import("plugin_lock.zig");
+const plugin_boot = @import("plugin_bootstrap.zig");
+
+const Dir = std.Io.Dir;
+const Io = std.Io;
+const EnvMap = std.process.Environ.Map;
+
+pub const Options = struct {
+    /// Run each plugin's own test suite while installing. Off by default — a
+    /// project routinely wires a dozen-plus already-released plugins, and
+    /// testing each costs a composer install plus a phpunit run.
+    verify: bool = false,
+};
+
+/// Record an installed plugin in plugins.lock.json, naming it if that fails.
+///
+/// The install itself succeeded, so this is not fatal — but a silent failure
+/// leaves the lock disagreeing with what is on disk, and the user with no idea
+/// which plugin to re-add.
+fn recordOrWarn(
+    allocator: std.mem.Allocator,
+    io: Io,
+    projectRoot: []const u8,
+    name: []const u8,
+    entry: lockfile.Entry,
+) void {
+    installer.recordInLock(allocator, io, projectRoot, entry) catch {
+        const msg = std.fmt.allocPrint(
+            allocator,
+            "{s}: installed, but could not be recorded in plugins.lock.json — run `hkm plugins add {s}` to repair the lock.",
+            .{ name, name },
+        ) catch return;
+        prompt.warn(msg);
+    };
+}
+
+/// Install every plugin `<projectRoot>/app/bootstrap/app.php` wires. Returns
+/// the number that could NOT be installed (0 when the bootstrap enables none,
+/// or when every enabled plugin installed cleanly).
+pub fn installEnabled(allocator: std.mem.Allocator, io: Io, env: *EnvMap, projectRoot: []const u8, opts: Options) !usize {
+    const bootstrap = try util.join(allocator, projectRoot, "app/bootstrap/app.php");
+    const source = Dir.cwd().readFileAlloc(io, bootstrap, allocator, .limited(4 * 1024 * 1024)) catch return 0;
+
+    var aliases: std.ArrayList(plugin_boot.Alias) = .empty;
+    try plugin_boot.collectAliases(allocator, source, &aliases);
+
+    var enabled: std.ArrayList(plugin_boot.Enabled) = .empty;
+    try plugin_boot.collectEnabled(allocator, source, aliases.items, &enabled);
+
+    if (enabled.items.len == 0) return 0;
+
+    prompt.section("Installing plugins");
+
+    var ok: usize = 0;
+    // Names, not just a count: the message that follows is the only place the
+    // user learns WHICH plugins are missing, and "3 of 19 failed" leaves them
+    // diffing the bootstrap against plugins/ to find out.
+    var failed: std.ArrayList([]const u8) = .empty;
+    for (enabled.items) |e| {
+        const outcome = installer.install(allocator, io, env, projectRoot, e.name, .{
+            .interactive = false,
+            .verify = opts.verify,
+        }) catch {
+            try failed.append(allocator, e.name);
+            continue;
+        };
+        switch (outcome) {
+            .refused => |why| {
+                try failed.append(allocator, e.name);
+                prompt.warn(why);
+            },
+            .installed, .up_to_date, .linked, .updated => {
+                ok += 1;
+                _ = installer.report(allocator, e.name, outcome, false) catch {};
+                // A lockfile write that fails is NOT a successful install:
+                // swallowing it left the command reporting success while
+                // plugins.lock.json did not record the plugin, so the next
+                // `hkm plugins` run cannot tell it is already there.
+                switch (outcome) {
+                    .installed, .up_to_date, .linked => |entry| recordOrWarn(allocator, io, projectRoot, e.name, entry),
+                    .updated => |u| recordOrWarn(allocator, io, projectRoot, e.name, u.to),
+                    .refused => {},
+                }
+            },
+        }
+    }
+
+    if (failed.items.len > 0) {
+        prompt.warn(try std.fmt.allocPrint(
+            allocator,
+            "{d} of {d} plugin(s) could not be installed — the project will not boot until they are:",
+            .{ failed.items.len, enabled.items.len },
+        ));
+        // One command per plugin, and no separate list of bare names above it:
+        // the commands already name every one, and printing both meant reading
+        // the same names twice. `install` takes a SINGLE plugin — its second
+        // positional is the project path, so space-joining the names would
+        // install the first and treat the rest as a directory.
+        for (failed.items) |name| {
+            prompt.muted(try std.fmt.allocPrint(allocator, "  hkm plugins install {s}", .{name}));
+        }
+    } else {
+        prompt.ok(try std.fmt.allocPrint(allocator, "{d} plugin(s) installed", .{ok}));
+    }
+
+    return failed.items.len;
+}

--- a/tools/src/lib/util.zig
+++ b/tools/src/lib/util.zig
@@ -231,6 +231,38 @@ pub fn chmodExec(io: Io, path: []const u8) void {
     f.setPermissions(io, @enumFromInt(0o755)) catch {};
 }
 
+/// Set a path's own mode bits (chmod) via `Dir.cwd()`, without having to open
+/// it first — works on both files and directories. No-op on Windows.
+/// Best-effort — swallows the error rather than propagating it, same contract
+/// as chmod600/chmodExec: a path that could not be rechmod'd (wrong owner, a
+/// read-only mount) should not fail the whole command.
+pub fn chmodPath(io: Io, path: []const u8, mode: u32) void {
+    if (@import("builtin").os.tag == .windows) return;
+    Dir.cwd().setFilePermissions(io, path, @enumFromInt(mode), .{}) catch {};
+}
+
+/// Recursively make `path` writable: `dirMode` (e.g. 0o775) on every directory
+/// including `path` itself, `fileMode` (e.g. 0o664) on every regular file
+/// beneath it. Fixes a runtime tree (var/, userdata/) left behind by a
+/// previous run under a different owner (root inside a container, a different
+/// dev's clone). Depth-limited and best-effort: a subtree that cannot be
+/// opened or rechmod'd is skipped rather than failing the caller.
+pub fn chmodTreeWritable(allocator: std.mem.Allocator, io: Io, path: []const u8, dirMode: u32, fileMode: u32, depth: usize) void {
+    chmodPath(io, path, dirMode);
+    if (depth == 0) return;
+
+    var dir = Dir.cwd().openDir(io, path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
+    var it = dir.iterate();
+    while (it.next(io) catch null) |entry| {
+        const child = std.fmt.allocPrint(allocator, "{s}/{s}", .{ path, entry.name }) catch continue;
+        switch (entry.kind) {
+            .directory => chmodTreeWritable(allocator, io, child, dirMode, fileMode, depth - 1),
+            else => chmodPath(io, child, fileMode),
+        }
+    }
+}
+
 // ── path strings ────────────────────────────────────────────────────────────
 
 /// Trim trailing path separators (keeps a lone "/").

--- a/tools/src/main.zig
+++ b/tools/src/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const new_cmd = @import("commands/new.zig");
+const install_cmd = @import("commands/install.zig");
 const update_cmd = @import("commands/update.zig");
 const run_cmd = @import("commands/run.zig");
 const list_cmd = @import("commands/list.zig");
@@ -24,6 +25,7 @@ fn printHelp(allocator: std.mem.Allocator, io: std.Io, env: *std.process.Environ
 
     prompt.section("Usage");
     prompt.item("hkm new <path> [opts]", "scaffold a new PhpServicePlatform project");
+    prompt.item("hkm install [path|name]", "register a project, restore var/userdata/plugins after a git clone");
     prompt.item("hkm run [path|name]", "run a project locally (PHP dev server)");
     prompt.item("hkm cli [command]", "run a project's console interactively");
     prompt.item("hkm worker [args]", "run a project's queue worker");
@@ -339,6 +341,11 @@ fn dispatch(init: std.process.Init.Minimal, mm: *memory.Manager) !u8 {
         var scope = CmdScope.begin(mm, "new");
         defer scope.end();
         return try new_cmd.run(scope.allocator(), io, &env_map, args);
+    }
+    if (std.mem.eql(u8, cmd, "install")) {
+        var scope = CmdScope.begin(mm, "install");
+        defer scope.end();
+        return try install_cmd.run(scope.allocator(), io, &env_map, args);
     }
     if (std.mem.eql(u8, cmd, "update")) {
         var scope = CmdScope.begin(mm, "update");


### PR DESCRIPTION
## Summary
- **`hkm install [path|name]`** — brings a cloned/pulled project up to a runnable state: registers it in the kernel registry, recreates the gitignored `var/`/`userdata/storage` runtime directories, creates `.env`/`APP_KEY` if missing, runs `composer install`, and fetches every plugin the project's bootstrap wires (`plugins/` is never committed to git). Every step past directory creation is skippable with a `--no-*` flag.
- **`--production` / `--owner=<user>[:<group>]`** — tightens `var/`/`userdata/` to `0750`/`0640` and `chown -R`s them to the account the web server / PHP-FPM pool actually runs as, reporting a failed chown per-directory instead of swallowing it. `HKM_PROD_OWNER` sets a default owner for a deploy environment.
- Extracted the plugin fetch-and-lock logic `hkm new` already had into `lib/plugin_provision.zig` so both commands share it instead of duplicating ~100 lines.
- Also carries `720c2cd` from master (uninstall review-finding fixes + output-split cleanup), already on `master` ahead of `v1.3.3`.

## Test plan
- [x] `zig build` — clean
- [x] `zig build test` — all passing
- [x] Full round-trip in a scratch dir: scaffolded a project, deleted `var/`, `userdata/`, `.env`, `plugins/`, `vendor/` to simulate a fresh clone, ran `hkm install`, confirmed directories/permissions/`.env`/registry were restored; confirmed a second run is idempotent (no key regeneration, no duplicate work)
- [x] `hkm install --production --owner=<user>:<group>` verified against a real filesystem — correct `0750`/`0640` mode bits and ownership
- [x] Verified a bad `--owner` reports the chown failure per-directory instead of failing silently
