### PR TITLE
release: v1.4.1 — fix hkm upgrade crashing with "Text file busy"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-08-28
+
+### Fixed
+- **`hkm upgrade --user` / `--system` crashing on a self-upgrade** — the
+  tarball's `tools/install.sh` replaced `bin/hkm` and `bin/hkm-config` with a
+  plain `cp`, which truncates and writes INTO the existing file. Since the
+  process running the upgrade IS that exact binary, the kernel it's running
+  under refuses with `cp: cannot create regular file '.../hkm': Text file
+  busy` — the same failure `hkm upgrade --local` was fixed for previously, just
+  never carried over to this installer. Now stages each binary beside its
+  target and `mv`s it over, so the running process keeps its old (unlinked)
+  inode and the next invocation picks up the new build.
+
 ## [1.4.0] - 2026-08-28
 
 A project's `plugins/`, `var/*` and `userdata/storage/*` are gitignored on

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -223,9 +223,17 @@ if [ -d "$DEST" ]; then mv "$DEST" "$OLD"; fi
 mv "$NEW" "$DEST"
 rm -rf "$OLD"
 
-cp "$SRC/bin/hkm"        "$BINDIR/hkm"
-cp "$SRC/bin/hkm-config" "$BINDIR/hkm-config"
-chmod +x "$BINDIR/hkm" "$BINDIR/hkm-config"
+# Stage beside the destination, then rename over it. A plain `cp` truncates
+# and writes INTO the existing file, which fails with "Text file busy" the
+# moment that exact binary is the one currently running this script — i.e.
+# every `hkm upgrade` that reaches this installer. rename() swaps the
+# directory entry instead: the running process keeps its old (now-unlinked)
+# inode and finishes normally, and the next invocation picks up the new build.
+cp "$SRC/bin/hkm"        "$BINDIR/.hkm.new.$$"
+cp "$SRC/bin/hkm-config" "$BINDIR/.hkm-config.new.$$"
+chmod +x "$BINDIR/.hkm.new.$$" "$BINDIR/.hkm-config.new.$$"
+mv "$BINDIR/.hkm.new.$$"        "$BINDIR/hkm"
+mv "$BINDIR/.hkm-config.new.$$" "$BINDIR/hkm-config"
 ok "Installed to $DEST"
 
 # ── drop a kernel pin this install makes redundant ──────────────────────────

--- a/tools/src/commands/doctor.zig
+++ b/tools/src/commands/doctor.zig
@@ -308,6 +308,7 @@ pub fn run(allocator: std.mem.Allocator, io: Io, env: *EnvMap, args: []const []c
     prompt.item("git", findOnPath(allocator, io, env, "git") orelse "absent — needed by `hkm plugins` git sources");
     prompt.item("node", findOnPath(allocator, io, env, "node") orelse "absent — needed by `hkm ui` (frontend only)");
     prompt.item("npm", findOnPath(allocator, io, env, "npm") orelse "absent — needed by `hkm ui` (frontend only)");
+    prompt.item("vips", findOnPath(allocator, io, env, "vips") orelse "absent — needed by libvips-based image processing (e.g. the Vips image driver)");
 
     // ── PHP runtime & extensions ────────────────────────────────────────────
     prompt.section("PHP runtime & extensions");


### PR DESCRIPTION
## Summary
- `hkm upgrade --user` (and `--system`) shelled out to the tarball's `tools/install.sh`, which replaced `bin/hkm`/`bin/hkm-config` with a plain `cp` — truncate-and-write into the currently-running binary, so every self-upgrade failed with `cp: cannot create regular file '.../hkm': Text file busy`.
- Fixed by staging each binary beside its target and `mv`-ing it over, the same pattern already used for the kernel directory swap a few lines above it, and for `hkm upgrade --local`'s launcher install (`tools/src/commands/upgrade.zig`).
- CHANGELOG bumped to `[1.4.1]` — merging to `main` triggers `auto-release.yml` → tag `v1.4.1` → build + publish.

## Test plan
- [x] Read-through: matches the already-working rename pattern used elsewhere in this exact file and in the Zig `--local` upgrade path.
- [ ] Not run end-to-end against a live install (would need a real `~/.local` install with the old launcher running) — the failure mode (ETXTBSY on cp) is standard Linux behavior, not specific to this repo's setup.
