### PR TITLE
release: v1.4.2 — macOS installer (tools/install-macos.sh)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,10 @@ jobs:
         run: VERSION="${RELEASE_VERSION:-${GITHUB_REF_NAME#v}}" ./tools/bundle.sh macos
       - uses: actions/upload-artifact@v7
         with: { name: macos-app, path: dist/*.tar.gz }
+      # Published alongside the assets so `curl | sh` works without a checkout
+      # — same reasoning as the Linux `installer` artifact below.
+      - uses: actions/upload-artifact@v7
+        with: { name: macos-installer, path: tools/install-macos.sh }
 
   # ── Publish GitHub Release with all artifacts ─────────────────────────────
   release:
@@ -148,6 +152,7 @@ jobs:
             artifacts/windows-zip/*.zip
             artifacts/macos-app/*.tar.gz
             artifacts/installer/install.sh
+            artifacts/macos-installer/install-macos.sh
           # Curated section (if present) goes first; GitHub appends the
           # auto-generated "What's Changed" / contributors below it.
           body_path: ${{ steps.notes.outputs.has_notes == 'true' && 'release-body.md' || '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.1] - 2026-08-28
 
+### Added
+- **`tools/install-macos.sh`** — a macOS-specific installer. Previously
+  `tools/install.sh` (Linux-only auto-download) simply refused to run on
+  macOS with no working alternative documented anywhere, leaving `HKM.app`
+  users to hand-discover that it needs the Gatekeeper quarantine flag cleared
+  and a `PATH` entry before `hkm` runs at all. The new installer downloads
+  (or accepts a local) `hkm-kernel-<version>-macos-universal.tar.gz`, swaps
+  `HKM.app` into `/Applications`, clears `com.apple.quarantine`, and wires
+  `hkm`/`hkm-config` onto `PATH` via a tiny `exec` wrapper script rather than
+  a symlink — `_NSGetExecutablePath` is not guaranteed to resolve through a
+  symlink the way Linux's `/proc/self/exe` does, and the launcher self-locates
+  its kernel relative to its own executable path, so a symlink risked it
+  silently finding the wrong kernel (or none). Shipped as its own release
+  asset (`install-macos.sh`) and bundled inside the macOS tarball itself,
+  mirroring how `install.sh` ships with the Linux one.
+
 ### Fixed
 - **`hkm upgrade --user` / `--system` crashing on a self-upgrade** — the
   tarball's `tools/install.sh` replaced `bin/hkm` and `bin/hkm-config` with a

--- a/tools/README.md
+++ b/tools/README.md
@@ -65,6 +65,29 @@ the run.
 Installing **PHP and its extensions** is the one part that needs an
 administrator. Everything else `doctor` reports, you can fix yourself.
 
+### macOS
+
+`tools/install.sh`'s auto-download only covers the Linux tarball; on macOS use
+`tools/install-macos.sh` instead — it installs `HKM.app` to `/Applications`,
+clears the Gatekeeper quarantine flag (required for an unsigned/unnotarized
+build to run at all), and wires `hkm`/`hkm-config` onto `PATH` via a tiny
+wrapper script:
+
+```sh
+curl -fsSL https://github.com/AlfaCode-Team/hkm-kernel/releases/latest/download/install-macos.sh | sh
+
+# or, from a downloaded tarball
+./tools/install-macos.sh hkm-kernel-1.4.1-macos-universal.tar.gz
+./tools/install-macos.sh --uninstall
+```
+
+`HKM.app` is not a double-click GUI app — `Contents/MacOS/hkm` is the same CLI
+binary as every other platform, just wrapped for Gatekeeper/Finder. The
+launcher self-locates its kernel relative to its own executable path, which is
+why the installer writes an `exec` wrapper script rather than a symlink onto
+`PATH` — see the comment at the top of `install-macos.sh` for why a symlink is
+unsafe here.
+
 ### The `.deb` (system-wide, needs root)
 
 `hkm-kernel_<version>_amd64.deb` installs `/opt/hkm-kernel` + `/usr/bin/hkm` for

--- a/tools/bundle.sh
+++ b/tools/bundle.sh
@@ -259,7 +259,9 @@ if [[ "$want" == all || "$want" == macos ]]; then
   <key>CFBundlePackageType</key><string>APPL</string>
 </dict></plist>
 EOF
-  ( cd "$DIST" && tar -czf "hkm-kernel-${VERSION}-macos-universal.tar.gz" HKM.app )
+  cp "$TOOLS/install-macos.sh" "$DIST/install-macos.sh"
+  chmod +x "$DIST/install-macos.sh"
+  ( cd "$DIST" && tar -czf "hkm-kernel-${VERSION}-macos-universal.tar.gz" HKM.app install-macos.sh && rm -f install-macos.sh )
   say "wrote $DIST/hkm-kernel-${VERSION}-macos-universal.tar.gz"
 fi
 

--- a/tools/install-macos.sh
+++ b/tools/install-macos.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env sh
+# ---------------------------------------------------------------------------
+# install-macos.sh — install the HKM kernel (HKM.app) and wire up `hkm` /
+# `hkm-config` on macOS.
+#
+#   ./install-macos.sh                                # download latest, install
+#   ./install-macos.sh hkm-kernel-1.4.1-macos-universal.tar.gz
+#   ./install-macos.sh --version v1.4.1               # download a specific tag
+#   ./install-macos.sh --uninstall
+#
+# Installs:
+#   /Applications/HKM.app                 the .app bundle (kernel + launcher)
+#   ~/.local/bin/hkm, hkm-config          tiny wrapper scripts onto PATH
+#
+# Your data is NOT inside the install tree and survives upgrades:
+#   ~/.config/hkm/config.env              launcher config
+#   ~/.local/share/hkm/                   project registry (HKM_USERDATA_DIR)
+#
+# tools/install.sh (the Linux auto-installer) deliberately refuses to run on
+# macOS — its auto-download only covers the Linux tarball — and points here.
+# HKM.app is NOT a double-click GUI app: Contents/MacOS/hkm is the exact same
+# CLI binary as every other platform, just wrapped for Gatekeeper/Finder.
+#
+# WHY A WRAPPER SCRIPT, NOT A SYMLINK ONTO PATH
+# ----------------------------------------------
+# The launcher finds its kernel relative to its OWN executable path
+# (tools/src/lib/kernel.zig selfLocateRoot(): "<dir>/../Resources/opt/hkm-kernel").
+# macOS's `_NSGetExecutablePath` is not guaranteed to resolve through a symlink
+# the way Linux's /proc/self/exe does, so `ln -s .../HKM.app/.../hkm
+# ~/.local/bin/hkm` risks the binary computing its own directory as
+# ~/.local/bin and never finding Resources/opt/hkm-kernel beside it — silently
+# falling back to the wrong kernel (or none). A one-line `exec` wrapper
+# sidesteps that: the OS execs the REAL binary at its real path regardless of
+# how it was invoked, so self-location always sees where it actually lives.
+#
+# Still needed from your system administrator, once: PHP >= 8.4 with the
+# extensions `hkm doctor` lists. Installing PHP is the one thing this install
+# genuinely cannot do for you.
+# ---------------------------------------------------------------------------
+set -eu
+
+REPO="${HKM_REPO:-AlfaCode-Team/hkm-kernel}"
+APPDIR="${HKM_APPDIR:-/Applications}"
+APPDST="$APPDIR/HKM.app"
+BINDIR="${HKM_BINDIR:-$HOME/.local/bin}"
+
+TARBALL=""
+WANT_TAG=""
+DO_UNINSTALL=0
+SKIP_COMPOSER=0
+
+# ── output helpers ──────────────────────────────────────────────────────────
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_B='\033[36m'; C_G='\033[32m'; C_Y='\033[33m'; C_R='\033[31m'; C_0='\033[0m'
+else
+  C_B=''; C_G=''; C_Y=''; C_R=''; C_0=''
+fi
+say()  { printf "${C_B}▶${C_0} %s\n" "$*"; }
+ok()   { printf "${C_G}✓${C_0} %s\n" "$*"; }
+warn() { printf "${C_Y}!${C_0} %s\n" "$*" >&2; }
+die()  { printf "${C_R}✗${C_0} %s\n" "$*" >&2; exit 1; }
+
+usage() {
+  sed -n '3,25p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+[ "$(uname -s)" = "Darwin" ] || die "this installer is for macOS only — Linux: tools/install.sh"
+
+# ── arguments ───────────────────────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)      usage ;;
+    --uninstall)    DO_UNINSTALL=1 ;;
+    --version)      shift; [ $# -gt 0 ] || die "--version needs a tag (e.g. v1.4.1)"; WANT_TAG="$1" ;;
+    --no-composer)  SKIP_COMPOSER=1 ;;
+    -*)             die "unknown option: $1  (try --help)" ;;
+    *)              TARBALL="$1" ;;
+  esac
+  shift
+done
+
+# ── uninstall ───────────────────────────────────────────────────────────────
+if [ "$DO_UNINSTALL" -eq 1 ]; then
+  say "Removing $APPDST"
+  if [ -w "$APPDIR" ]; then rm -rf "$APPDST"; else sudo rm -rf "$APPDST"; fi
+  rm -f "$BINDIR/hkm" "$BINDIR/hkm-config"
+  ok "Removed. Your data was left alone:"
+  printf '    %s\n    %s\n' "${XDG_CONFIG_HOME:-$HOME/.config}/hkm" \
+                            "${XDG_DATA_HOME:-$HOME/.local/share}/hkm"
+  exit 0
+fi
+
+# ── what is already on this machine ─────────────────────────────────────────
+kernel_version() { # $1 = kernel root → prints the stamped version, or nothing
+  [ -f "$1/composer.json" ] || return 0
+  sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1/composer.json" | head -1
+}
+OLD_VER="$(kernel_version "$APPDST/Contents/Resources/opt/hkm-kernel")"
+[ -d "$APPDST" ] && say "Existing install: $APPDST (${OLD_VER:-unstamped})"
+
+# ── acquire the tarball ─────────────────────────────────────────────────────
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT INT TERM
+
+fetch() { # $1 = url, $2 = out
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$1" -o "$2"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$2" "$1"
+  else
+    die "need curl or wget to download (or pass a .tar.gz path)"
+  fi
+}
+
+if [ -n "$TARBALL" ]; then
+  [ -f "$TARBALL" ] || die "no such file: $TARBALL"
+  say "Using $TARBALL"
+else
+  if [ -n "$WANT_TAG" ]; then
+    TAG="$WANT_TAG"
+  else
+    say "Looking up the latest release of $REPO…"
+    API="https://api.github.com/repos/$REPO/releases/latest"
+    fetch "$API" "$TMP/rel.json" || die "could not reach GitHub. Download the tarball and pass its path."
+    TAG="$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$TMP/rel.json" | head -1)"
+    [ -n "$TAG" ] || die "could not parse the latest tag. Pass --version vX.Y.Z or a tarball path."
+  fi
+
+  VER="${TAG#v}"
+  NAME="hkm-kernel-${VER}-macos-universal.tar.gz"
+  URL="https://github.com/$REPO/releases/download/$TAG/$NAME"
+  say "Downloading $NAME"
+  fetch "$URL" "$TMP/$NAME" || die "download failed: $URL"
+  TARBALL="$TMP/$NAME"
+fi
+
+# ── unpack and validate before touching the destination ─────────────────────
+say "Unpacking…"
+mkdir -p "$TMP/x"
+tar -xzf "$TARBALL" -C "$TMP/x" || die "could not extract $TARBALL"
+SRC_APP="$TMP/x/HKM.app"
+[ -d "$SRC_APP" ] || die "unexpected archive layout (no HKM.app at the top level)"
+[ -x "$SRC_APP/Contents/MacOS/hkm" ] || die "launcher missing from the archive (Contents/MacOS/hkm)"
+
+# ── install ─────────────────────────────────────────────────────────────────
+# Swap rather than overwrite in place, same reasoning as the Linux installer:
+# a half-copied .app is worse than the old one, and this also means a
+# currently-running `hkm` (launched from the old .app) is unaffected — it
+# keeps its old, now-unlinked inode and finishes normally.
+if [ -w "$APPDIR" ]; then SUDO=""; else SUDO="sudo"; warn "$APPDIR is not writable — using sudo"; fi
+
+NEW="$APPDIR/.HKM.app.new.$$"
+OLD="$APPDIR/.HKM.app.old.$$"
+$SUDO rm -rf "$NEW"
+$SUDO cp -R "$SRC_APP" "$NEW"
+if [ -d "$APPDST" ]; then $SUDO mv "$APPDST" "$OLD"; fi
+$SUDO mv "$NEW" "$APPDST"
+$SUDO rm -rf "$OLD"
+$SUDO chmod +x "$APPDST/Contents/MacOS/hkm" "$APPDST/Contents/MacOS/hkm-config"
+
+# Clear the quarantine flag Gatekeeper sets on anything downloaded — without
+# this an unsigned/unnotarized build refuses to run at all ("cannot be opened
+# because the developer cannot be verified"). Best effort: a local --local-style
+# copy may carry no quarantine attribute, and that is not an error.
+$SUDO xattr -dr com.apple.quarantine "$APPDST" 2>/dev/null || true
+
+ok "Installed to $APPDST"
+
+# ── wrapper scripts onto PATH (see header for why not a symlink) ────────────
+mkdir -p "$BINDIR"
+for name in hkm hkm-config; do
+  staged="$BINDIR/.$name.new.$$"
+  printf '#!/bin/sh\nexec "%s/Contents/MacOS/%s" "$@"\n' "$APPDST" "$name" > "$staged"
+  chmod +x "$staged"
+  mv "$staged" "$BINDIR/$name"
+done
+ok "wired up $BINDIR/hkm, hkm-config"
+
+# ── PATH ────────────────────────────────────────────────────────────────────
+case ":${PATH}:" in
+  *":$BINDIR:"*) ok "$BINDIR is on your PATH" ;;
+  *)
+    warn "$BINDIR is NOT on your PATH."
+    printf '  Add it, then open a new terminal:\n'
+    case "${SHELL##*/}" in
+      fish) printf '    fish_add_path %s\n' "$BINDIR" ;;
+      *)    printf '    echo '\''export PATH="%s:$PATH"'\'' >> ~/.zprofile\n' "$BINDIR" ;;
+    esac
+    ;;
+esac
+
+# ── PHP dependencies (best effort — NEVER a precondition) ───────────────────
+KERNEL_ROOT="$APPDST/Contents/Resources/opt/hkm-kernel"
+if [ "$SKIP_COMPOSER" -eq 1 ]; then
+  say "Skipping dependency resolution (--no-composer)."
+elif ! command -v php >/dev/null 2>&1; then
+  say "No php on PATH — skipping dependency resolution for now."
+elif [ -x "$KERNEL_ROOT/install.sh" ]; then
+  say "Resolving PHP dependencies (composer install --no-dev)…"
+  ( cd "$KERNEL_ROOT" && ./install.sh ) || warn "Dependency resolution did not complete — hkm doctor will show why."
+else
+  say "Resolving PHP dependencies (composer install --no-dev)…"
+  ( cd "$KERNEL_ROOT" && composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist ) \
+    || warn "Dependency resolution did not complete — hkm doctor will show why."
+fi
+
+# ── verify ──────────────────────────────────────────────────────────────────
+printf '\n'
+DOCTOR_OK=1
+if [ -x "$BINDIR/hkm" ]; then
+  say "Checking what the kernel still needs…"
+  "$BINDIR/hkm" doctor || DOCTOR_OK=0
+fi
+
+printf '\n'
+NEW_VER="$(kernel_version "$KERNEL_ROOT")"
+if [ -n "$OLD_VER" ] && [ -n "$NEW_VER" ] && [ "$OLD_VER" != "$NEW_VER" ]; then
+  printf '  Version: %s -> %s\n' "$OLD_VER" "$NEW_VER"
+elif [ -n "$NEW_VER" ]; then
+  printf '  Version: %s\n' "$NEW_VER"
+fi
+
+if [ "$DOCTOR_OK" -eq 0 ]; then
+  printf '  Some requirements are not met yet — see "Must fix" above.\n'
+  printf '  Re-check any time with:  hkm doctor\n'
+fi
+printf '  App:     %s\n' "$APPDST"
+printf '  Config:  %s/hkm/config.env\n' "${XDG_CONFIG_HOME:-$HOME/.config}"
+printf '  Data:    %s/hkm\n' "${XDG_DATA_HOME:-$HOME/.local/share}"
+printf '  Remove:  %s --uninstall\n' "$0"
+printf '\n'

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -158,6 +158,9 @@ if [ -n "$TARBALL" ]; then
   say "Using $TARBALL"
 else
   OS="$(uname -s)"
+  if [ "$OS" = "Darwin" ]; then
+    die "macOS uses a separate installer — tools/install-macos.sh (curl -fsSL https://github.com/$REPO/releases/latest/download/install-macos.sh | sh)"
+  fi
   [ "$OS" = "Linux" ] || die "auto-download supports Linux; on $OS use the .app/.zip bundle, or pass a tarball"
   ARCH="$(arch_slug)"
 


### PR DESCRIPTION
## Summary
- `tools/install.sh`'s auto-download only ever covered Linux; on macOS it just refused with "auto-download supports Linux ... use the .app/.zip bundle", and nothing (script or README) explained what to actually do with that bundle. `HKM.app` isn't a double-click GUI app — `Contents/MacOS/hkm` is the same CLI binary as every other platform — and needs the Gatekeeper quarantine flag cleared plus its launcher wired onto `PATH` before `hkm` runs at all.
- New `tools/install-macos.sh`: downloads/accepts the `hkm-kernel-<version>-macos-universal.tar.gz`, swaps `HKM.app` into `/Applications` (same rename-swap safety as the Linux installer), clears `com.apple.quarantine`, and writes an `exec` wrapper script onto `PATH` — deliberately **not** a symlink, since `_NSGetExecutablePath` isn't guaranteed to resolve through one the way Linux's `/proc/self/exe` does, and the launcher self-locates its kernel relative to its own executable path.
- Wired into `bundle.sh`/`release.yml` so it ships both inside the macOS tarball and as its own release asset (`install-macos.sh`), matching how `install.sh` ships for Linux.
- `tools/README.md` gets a short macOS section; `tools/install.sh`'s Darwin refusal now points at this script by name.
- CHANGELOG bumped to `[1.4.2]` (branched fresh off `main`, since `v1.4.1` is already tagged/published — auto-release.yml skips a version it already has a tag for).

## Test plan
- [x] `sh -n` on both install scripts, `bash -n` on bundle.sh, YAML-parsed release.yml — all clean.
- [ ] Not run end-to-end on a real Mac (no macOS box available here) — the Gatekeeper-quarantine and self-location reasoning is standard macOS/Zig behavior, not verified against a live install.
