### PR TITLE
fix(changelog): correct the v1.4.2 heading merged in as v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.1] - 2026-08-28
+## [1.4.2] - 2026-08-28
 
 ### Added
 - **`tools/install-macos.sh`** — a macOS-specific installer. Previously
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   silently finding the wrong kernel (or none). Shipped as its own release
   asset (`install-macos.sh`) and bundled inside the macOS tarball itself,
   mirroring how `install.sh` ships with the Linux one.
+
+## [1.4.1] - 2026-08-28
 
 ### Fixed
 - **`hkm upgrade --user` / `--system` crashing on a self-upgrade** — the


### PR DESCRIPTION
## Summary
- #116's CHANGELOG entry was meant to head a new `[1.4.2]` version but got committed still headed `[1.4.1]` — a stray edit that wasn't re-staged before commit on my end. `v1.4.1` already has a tag, so `auto-release.yml` correctly read the top heading, saw the tag already existed, and skipped without publishing a `v1.4.2` build.
- The macOS-installer code itself is already on `main` from #116 — this is a one-line relabel so the version bump is actually detected and the tag/build get created.

## Test plan
- [x] Diffed against `origin/main` — only the two heading lines change, content is otherwise untouched.
