### PR TITLE
release: v1.4.3 — fix installers crashing on an unset $SHELL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.3] - 2026-08-28
+
+### Fixed
+- **`install.sh` / `install-macos.sh` crashing with `unbound variable`.** Both
+  installers' PATH hint used `${SHELL##*/}`, which throws under `set -u`
+  whenever `$SHELL` isn't exported in the invoking environment — unlike
+  `$HOME`, POSIX doesn't guarantee it, and it's commonly absent under
+  `curl | sh`, cron, and some IDE task runners. Guarded with `${SHELL:-}` and
+  matched by suffix instead, so a missing value now just falls through to the
+  generic PATH-hint case instead of aborting the whole install.
+
 ## [1.4.2] - 2026-08-28
 
 ### Added

--- a/tools/install-macos.sh
+++ b/tools/install-macos.sh
@@ -184,8 +184,8 @@ case ":${PATH}:" in
   *)
     warn "$BINDIR is NOT on your PATH."
     printf '  Add it, then open a new terminal:\n'
-    case "${SHELL##*/}" in
-      fish) printf '    fish_add_path %s\n' "$BINDIR" ;;
+    case "${SHELL:-}" in
+      */fish) printf '    fish_add_path %s\n' "$BINDIR" ;;
       *)    printf '    echo '\''export PATH="%s:$PATH"'\'' >> ~/.zprofile\n' "$BINDIR" ;;
     esac
     ;;

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -304,10 +304,10 @@ case ":${PATH}:" in
   *)
     warn "$BINDIR is NOT on your PATH."
     printf '  Add it, then open a new terminal:\n'
-    case "${SHELL##*/}" in
-      zsh)  printf '    echo '\''export PATH="%s:$PATH"'\'' >> ~/.zshrc\n' "$BINDIR" ;;
-      fish) printf '    fish_add_path %s\n' "$BINDIR" ;;
-      *)    printf '    echo '\''export PATH="%s:$PATH"'\'' >> ~/.bashrc\n' "$BINDIR" ;;
+    case "${SHELL:-}" in
+      */zsh)  printf '    echo '\''export PATH="%s:$PATH"'\'' >> ~/.zshrc\n' "$BINDIR" ;;
+      */fish) printf '    fish_add_path %s\n' "$BINDIR" ;;
+      *)      printf '    echo '\''export PATH="%s:$PATH"'\'' >> ~/.bashrc\n' "$BINDIR" ;;
     esac
     ;;
 esac


### PR DESCRIPTION
## Summary
- The `$SHELL` guard was meant to land in v1.4.2 (#117) but that PR got merged right after its first commit (the changelog heading fix) — before the second commit with this fix was pushed. So v1.4.2 shipped without it, and `install-macos.sh` crashes with `unbound variable` on any macOS environment where `$SHELL` isn't exported (confirmed: `curl | sh`, some IDE-launched shells).
- Re-applying the same fix (cherry-picked from the orphaned commit) as its own `v1.4.3`, since `v1.4.2` is already tagged.
- Fixes both `tools/install.sh` and `tools/install-macos.sh` — same latent bug in both, `${SHELL##*/}` → `${SHELL:-}` + suffix match.

## Test plan
- [x] Reproduced the exact crash and confirmed the fix: `env -u SHELL sh -c 'set -eu; case "${SHELL##*/}" in *) echo ok;; esac'` fails with `parameter not set`; the same with `${SHELL:-}` succeeds.
- [x] `sh -n` on both scripts.
- [x] Diffed this branch against `main` before opening — confirmed only the intended 3-file change, nothing else pending.
