### PR TITLE
fix(ci): grant release.yml the pull-requests scope its homebrew job needs

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,8 +14,11 @@ name: Auto Release
     paths:
       - CHANGELOG.md            # only a version bump can start a release
 
+# Kept in step with the `release` job's block below — the two are separate
+# grants and drifting apart is what invalidates the workflow.
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: auto-release
@@ -75,7 +78,16 @@ jobs:
     needs: detect
     if: needs.detect.outputs.release == 'true'
     uses: ./.github/workflows/release.yml
+    # A called workflow cannot be granted more than its CALLER holds, so every
+    # permission any job in release.yml asks for must be listed here too.
+    # Omitting one is not a runtime warning: GitHub rejects the whole file
+    # before a single job starts ("startup_failure"), so no release happens and
+    # `detect` never even runs to create the tag.
+    #
+    # pull-requests: write is for release.yml's `homebrew` job, which opens a PR
+    # carrying the formula's sha256 when it cannot push to main directly.
     permissions:
       contents: write
+      pull-requests: write
     with:
       version: ${{ needs.detect.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     reviews, and without the fallback the bump would simply be dropped. It
     never fails the workflow: the release is already out by then, and failing
     would only misreport a good release as broken.
+  - `auto-release.yml` grants that job's `pull-requests: write` through to
+    `release.yml`. A called workflow cannot hold more than its caller, and the
+    shortfall is not a warning — GitHub rejects the whole file at startup, so
+    the release does not run at all and no tag is created.
 
 ### Changed
 - **The macOS install is user-local by default — no root.** `install-macos.sh`


### PR DESCRIPTION
The v1.5.0 release never started. `auto-release.yml` calls `release.yml` as a reusable workflow, and **a called workflow cannot hold more permissions than its caller**. `release.yml`'s new `homebrew` job asks for `pull-requests: write` — it opens a PR with the formula's sha256 when it cannot push to `main` — while the caller granted only `contents: write`.

```
Invalid workflow file: .github/workflows/auto-release.yml#L73
The nested job 'homebrew' is requesting 'pull-requests: write',
but is only allowed 'pull-requests: none'.
```

That shortfall is not a runtime warning: GitHub rejects the whole file before any job starts. The run failed in 2 seconds with `startup_failure`, so `detect` never ran and **no `v1.5.0` tag was created**. Nothing was published and nothing needs unwinding.

## Fix

Both permission blocks in `auto-release.yml` — the workflow default and the `release` job that makes the call — now carry `pull-requests: write`, with a comment that they must be kept in step with `release.yml`'s jobs.

## Verified

Audited every job in `release.yml` against what the caller grants, so the same class of mismatch cannot hide elsewhere:

```
caller grants: {"contents"=>"write", "pull-requests"=>"write"}
  nested homebrew: {"contents"=>"write", "pull-requests"=>"write"} -> GRANTED
```

Both workflow files parse, and the release trigger still resolves correctly:

```
detected: '1.5.0'          tag v1.5.0 free — will release
```

The CHANGELOG entry is part of the fix, not padding: `auto-release.yml` only triggers on `paths: [CHANGELOG.md]`, so a workflow-only commit would merge without starting a release.

Merging this publishes v1.5.0.
