### PR TITLE
chore(homebrew): point the formula at v1.5.0

### DIFF
--- a/HomebrewFormula/hkm.rb
+++ b/HomebrewFormula/hkm.rb
@@ -29,15 +29,8 @@
 class Hkm < Formula
   desc "CLI for the HKM kernel, a modular PHP service platform"
   homepage "https://github.com/AlfaCode-Team/hkm-kernel"
-  # PLACEHOLDER-DIGEST: v1.5.0 is the release that first carries this formula,
-  # so the digest below cannot exist yet and `brew install` will fail its
-  # checksum until that release ships. tools/homebrew-bump.sh rewrites the three
-  # lines under this notice and deletes the notice itself once the pin is real.
-  # No `version` line: Homebrew scans it out of the asset filename, and
-  # `brew audit` rejects stating it twice. It also removes the only way for the
-  # version and the URL to ever disagree.
   url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.5.0/hkm-kernel-1.5.0-macos-universal.tar.gz"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  sha256 "20e624db28e998cf088b19ae20453bc53c421aa0432f35a625b83515b2a3d1de"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
Repoints `HomebrewFormula/hkm.rb` at the published `v1.5.0` assets — the release URL, and the sha256 of the macOS tarball as actually downloaded from it.

Verified against the live asset:

```
formula:      20e624db28e998cf088b19ae20453bc53c421aa0432f35a625b83515b2a3d1de
curl|shasum:  20e624db28e998cf088b19ae20453bc53c421aa0432f35a625b83515b2a3d1de
```

The `PLACEHOLDER-DIGEST` notice is stripped, as intended once a real pin lands.

## Why this is opened by hand

The `homebrew` job produced this branch correctly, then could not open the PR:

```
pull request create failed: GraphQL: GitHub Actions is not permitted
to create or approve pull requests (createPullRequest)
```

That is the repo setting **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests**, which is off by default. A follow-up PR makes the job degrade gracefully instead of failing, and documents the two settings that make it fully automatic.

**Until this merges, `brew install hkm` fails its checksum** — this is the first release to carry the formula, so the committed digest is still the placeholder.
