### PR TITLE
docs: the Homebrew install needs `brew trust`, which we did not document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was marked failed. Both blocked paths now degrade to warnings that name the
   branch, a ready-made compare link, and the two settings that make the bump
   fully automatic. The release itself was never at risk; only the report was.
+- **The documented Homebrew install did not work as written.** Homebrew 6
+  refuses to load a formula from a third-party tap until it is trusted, and it
+  refuses at `brew install` rather than at `brew tap` — so the two-line
+  instruction appeared to succeed and then failed with "Refusing to load formula
+  … from untrusted tap". `brew trust alfacode-team/hkm` is now part of the
+  documented sequence, in the README and in the formula's own header.
 
 ## [1.5.0] - 2026-08-28
 

--- a/HomebrewFormula/hkm.rb
+++ b/HomebrewFormula/hkm.rb
@@ -2,7 +2,12 @@
 # Homebrew formula for the HKM kernel.
 #
 #   brew tap alfacode-team/hkm https://github.com/AlfaCode-Team/hkm-kernel
+#   brew trust alfacode-team/hkm
 #   brew install hkm
+#
+# The `brew trust` step is required: Homebrew 6 refuses to load a formula from a
+# third-party tap until it is trusted, and it refuses at `brew install` — so
+# `brew tap` reports success and the failure surfaces one command later.
 #
 # This repository doubles as its own tap: Homebrew reads formulae from a
 # `HomebrewFormula/` directory in any tapped repo, so there is no second

--- a/README.md
+++ b/README.md
@@ -188,9 +188,14 @@ hkm doctor        # verify PHP + extensions
 **macOS (Homebrew)** — the shortest path; `php` and `composer` come with it.
 ```bash
 brew tap alfacode-team/hkm https://github.com/AlfaCode-Team/hkm-kernel
+brew trust alfacode-team/hkm
 brew install hkm
 hkm doctor
 ```
+`brew trust` is not optional. Homebrew 6 refuses to load a formula from a
+third-party tap until you say you trust it, and it refuses at `brew install`
+rather than at `brew tap` — so without that line the tap appears to succeed and
+the install then fails with *"Refusing to load formula … from untrusted tap"*.
 
 **macOS (installer)** — no root, like the Linux installer: `HKM.app` goes to
 `~/Applications`, the Gatekeeper quarantine flag is cleared, and `hkm` /


### PR DESCRIPTION
Homebrew 6 refuses to load a formula from a third-party tap until it is trusted — and it refuses at `brew install`, not at `brew tap`. The README's two-line instruction therefore reported success on the tap and then failed one command later:

```
Error: Refusing to load formula alfacode-team/hkm/hkm from untrusted tap alfacode-team/hkm.
Run `brew trust --formula alfacode-team/hkm/hkm` or `brew trust alfacode-team/hkm` to trust it.
```

Anyone following the README as written hit this. I only found it by running the instructions rather than trusting them.

## Change

```bash
brew tap alfacode-team/hkm https://github.com/AlfaCode-Team/hkm-kernel
brew trust alfacode-team/hkm          # ← added
brew install hkm
hkm doctor
```

Added to the README and to the formula's own header, with the reason it can't be skipped — the *delayed* failure is what makes it confusing rather than self-evident.

## Verified

Ran the documented sequence against the published v1.5.0 release:

```
Tapped 1 formula (573 files, 9.4MB).
install exit: 0
🍺  /opt/homebrew/Cellar/hkm/1.5.0: 5,018 files, 59.4MB
│  ✓ everything the kernel needs is present.
```

Note: `brew untrust` did not clear the trust state on re-test, so that run exercised the happy path only. The untrusted failure above was observed directly, before trusting the tap.
