### PR TITLE
chore(homebrew): point the formula at v1.6.0

### DIFF
--- a/HomebrewFormula/hkm.rb
+++ b/HomebrewFormula/hkm.rb
@@ -34,8 +34,8 @@
 class Hkm < Formula
   desc "CLI for the HKM kernel, a modular PHP service platform"
   homepage "https://github.com/AlfaCode-Team/hkm-kernel"
-  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.5.0/hkm-kernel-1.5.0-macos-universal.tar.gz"
-  sha256 "20e624db28e998cf088b19ae20453bc53c421aa0432f35a625b83515b2a3d1de"
+  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.6.0/hkm-kernel-1.6.0-macos-universal.tar.gz"
+  sha256 "db51e9a5301a7ff7db1c9b652d262ce0a4c748d634a923c062203845bb2a3515"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
The release workflow generated this bump correctly and could not land it: a direct push to `main` is refused by branch protection, and the `gh pr create` fallback is refused because **"Allow GitHub Actions to create and approve pull requests" is disabled above the repository** and cannot be enabled here. The job degraded to a warning and pushed the branch — which is the v1.5.0 fix working as designed. Only the bump is stranded; the release itself published correctly.

## Until this merges

`brew install hkm` installs **1.5.0**, silently. It does not fail a checksum — the 1.5.0 asset still exists and its hash is right — so a user simply gets the previous kernel while the release page says 1.6.0 is latest. `brew upgrade hkm` is a no-op for anyone who already has it.

## Hash verified against the published asset

```
published v1.6.0 macos-universal : db51e9a5301a7ff7db1c9b652d262ce0a4c748d634a923c062203845bb2a3515
this formula                     : db51e9a5301a7ff7db1c9b652d262ce0a4c748d634a923c062203845bb2a3515
```

Downloaded from the release and hashed locally, not taken on trust from the workflow log.

Two lines, `url` and `sha256`. Nothing else in the formula changes.
