### PR TITLE
chore(homebrew): point the formula at v1.6.1

### DIFF
--- a/HomebrewFormula/hkm.rb
+++ b/HomebrewFormula/hkm.rb
@@ -34,8 +34,8 @@
 class Hkm < Formula
   desc "CLI for the HKM kernel, a modular PHP service platform"
   homepage "https://github.com/AlfaCode-Team/hkm-kernel"
-  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.6.0/hkm-kernel-1.6.0-macos-universal.tar.gz"
-  sha256 "db51e9a5301a7ff7db1c9b652d262ce0a4c748d634a923c062203845bb2a3515"
+  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.6.1/hkm-kernel-1.6.1-macos-universal.tar.gz"
+  sha256 "3f4de9e3666be8f7333d905cc6d778994308bdf057bef69a92d084ed5a24e767"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
Carries the formula's `url` + `sha256` for **v1.6.1**. Produced by the `homebrew` job of the release run for `v1.6.1` (`tools/homebrew-bump.sh`) — not hand-edited.

```
url    .../releases/download/v1.6.1/hkm-kernel-1.6.1-macos-universal.tar.gz
sha256 3f4de9e3666be8f7333d905cc6d778994308bdf057bef69a92d084ed5a24e767
```

Verified against the published asset:

```
$ gh release download v1.6.1 --pattern '*macos-universal.tar.gz'
$ shasum -a 256 hkm-kernel-1.6.1-macos-universal.tar.gz
3f4de9e3666be8f7333d905cc6d778994308bdf057bef69a92d084ed5a24e767
```

## Why this PR is manual

The job pushed the branch but could not open the PR itself:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

It degrades to a warning rather than failing, so the release run stayed green while the formula stayed on v1.6.0. Its own suggested remedies, either of which makes this step automatic again:

- **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"**, or
- let `github-actions[bot]` bypass branch protection on `main`, which skips the PR entirely.

Until one is set, every release needs this PR opened by hand — v1.6.0 needed the same (#125).