### PR TITLE
ci(release): make a skipped Homebrew bump impossible to miss

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -19,6 +19,7 @@ name: Auto Release
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: auto-release
@@ -86,8 +87,13 @@ jobs:
     #
     # pull-requests: write is for release.yml's `homebrew` job, which opens a PR
     # carrying the formula's sha256 when it cannot push to main directly.
+    # issues: write is that job's LAST resort — when even the PR is refused (an
+    # org can withhold PR creation from Actions across every repo), it files a
+    # tracked issue instead, because a warning on a run page is not a signal
+    # anyone sees. Issue creation is not covered by the pull-request policy.
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     with:
       version: ${{ needs.detect.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,12 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # For the last-resort reminder issue below. Deliberately a SEPARATE grant
+      # from pull-requests: the "Allow GitHub Actions to create and approve pull
+      # requests" policy — which an ORG can withhold from every repo, with no
+      # repo-level override — does not cover issues. So this permission still
+      # works in exactly the case where the pull-request path cannot.
+      issues: write
     steps:
       # The formula lives on main; a tag push checks out the tag by default.
       - uses: actions/checkout@v5
@@ -279,11 +285,66 @@ jobs:
           fi
 
           # Opening a PR is a permission the repo can withhold from Actions —
-          # "Allow GitHub Actions to create and approve pull requests", off by
-          # default — and it fails at the API, after the branch is already
-          # pushed. Failing the job here reported a release that HAD published
-          # successfully as broken, which is the opposite of useful. The bump is
-          # safe on the branch, so say how to finish it and exit clean.
-          echo "::warning::Could not open the pull request automatically; the branch is pushed and ready."
-          echo "::warning::Open it: https://github.com/$GITHUB_REPOSITORY/compare/main...$BRANCH?expand=1"
-          echo "::warning::To automate this, either (a) enable Settings > Actions > General > 'Allow GitHub Actions to create and approve pull requests', or (b) let github-actions[bot] bypass branch protection on main, which skips the PR entirely."
+          # "Allow GitHub Actions to create and approve pull requests" — and so
+          # can the ORG, for every repo at once, which no repo-level setting can
+          # override (the repo API answers 409 "The organization does not allow
+          # GitHub Actions to create or approve pull requests"). It fails at the
+          # API, after the branch is already pushed.
+          #
+          # Failing the job here would report a release that HAD published
+          # successfully as broken, which is the opposite of useful.
+          #
+          # But exiting clean with nothing but ::warning:: was worse in a
+          # quieter way. Warnings live on the run page and nowhere else, so
+          # v1.6.1 published all-green while the formula on main still said
+          # v1.6.0 — a state nobody discovered until someone read this job's log
+          # by hand. A release that silently ships the WRONG formula to every
+          # `brew install` is not a release that should look identical to one
+          # that worked.
+          #
+          # So: stay green (the artifacts really are published), and leave a
+          # signal that outlives the run page.
+          COMPARE_URL="https://github.com/$GITHUB_REPOSITORY/compare/main...$BRANCH?expand=1"
+
+          {
+            echo "## ⚠️ Homebrew formula was NOT bumped"
+            echo
+            echo "\`v$VERSION\` published successfully, but \`HomebrewFormula/hkm.rb\` on \`main\`"
+            echo "still points at the **previous** release. Until the bump lands,"
+            echo "\`brew install hkm\` installs the old version — or fails its checksum."
+            echo
+            echo "The bump is committed and pushed to \`$BRANCH\`; only the pull request is missing."
+            echo
+            echo "**Finish the release:** [open the PR]($COMPARE_URL)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::warning::Homebrew formula NOT bumped — finish it at $COMPARE_URL"
+
+          # A tracked issue is the part that survives. Skip it when one is
+          # already open, so a re-run of the same release does not file a second.
+          TITLE="Homebrew formula not bumped for v$VERSION"
+          if [ -n "$(gh issue list --state open --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')" ]; then
+            echo "::notice::reminder issue for v$VERSION is already open"
+            exit 0
+          fi
+
+          cat > issue-body.md <<EOF
+          The \`v$VERSION\` release published successfully, but the Homebrew formula on \`main\` still points at the previous release. Every \`brew install hkm\` / \`brew upgrade hkm\` gets the old version until this is resolved.
+
+          The bump is already committed, pushed and ready — only the pull request could not be opened:
+
+          > \`GitHub Actions is not permitted to create or approve pull requests\`
+
+          **To finish this release:** $COMPARE_URL
+
+          ### Why this is manual
+
+          Opening the PR needs "Allow GitHub Actions to create and approve pull requests". That setting can be withheld at the ORGANIZATION level, which no repository-level setting can override — so this will recur on every release until an org admin changes it, or the step is done by hand each time.
+
+          Note that the org-level switch also lets Actions **approve** pull requests, which on a branch requiring reviews means a workflow could satisfy that requirement itself. Leaving it off and opening this PR by hand is the more conservative trade.
+
+          Filed automatically by the \`homebrew\` job in \`.github/workflows/release.yml\`.
+          EOF
+
+          gh issue create --title "$TITLE" --body-file issue-body.md \
+            || echo "::warning::could not file the reminder issue either — $COMPARE_URL"


### PR DESCRIPTION
## What happened

`v1.6.1` published with **every job green** while `HomebrewFormula/hkm.rb` on `main` still pointed at **v1.6.0**.

Nothing was actually broken — the digest was computed correctly and pushed to `homebrew/bump-v1.6.1` — but the final step, opening the PR, was refused:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

The job emitted `::warning::` and exited clean. Warnings live on the run page and nowhere else, so a release that ships the **wrong formula to every `brew install`** looked identical to one that worked. It was found by reading the job log by hand.

## What this changes

Staying green is still correct — the artifacts really are published, and failing the job would report a successful release as broken. What was missing is a signal that outlives the run page. The fallback now additionally:

- writes a **step summary** naming the stale formula and linking the compare URL;
- files a **tracked issue** (skipped if one is already open, so a re-run doesn't file a second).

Issue creation is the fallback for the PR path rather than a duplicate of it. The *"Allow GitHub Actions to create and approve pull requests"* policy can be withheld by the **organization** for every repo at once — no repo-level setting overrides it; the repo API answers `409 The organization does not allow GitHub Actions to create or approve pull requests` — and **that policy does not cover issues**. So this path works precisely when the PR path cannot.

`issues: write` is added in **three** places, not one: the `homebrew` job, and *both* permission blocks in `auto-release.yml`. A called workflow cannot be granted more than its caller holds, and omitting one is not a runtime warning — GitHub rejects the whole file before a single job starts.

## Deliberately not done

Neither remedy the old warning suggested:

- **Lifting the org policy** enables *create and approve* across every repo in the org. With `main` requiring 1 approval, a workflow could satisfy that requirement itself — on a public repo taking fork PRs, that's a supply-chain escalation path.
- **A `github-actions[bot]` bypass on `main`** would let the bot push while skipping code-owner review and all four required checks, and requires migrating `main` off classic branch protection (classic protection has no bypass-actor list; it is a rulesets-only feature, and the two systems are additive, so the classic rule would have to be removed). `enforce_admins: true` says maintainers hold themselves to the rules; a bot should not sit above them.

For a public repository, "every commit on `main` was reviewed and passed its checks" is a property people rely on when auditing the project. One click per release is the cheaper side of that trade.

## Verification

- Both workflows parse as YAML.
- All three shell steps in the `homebrew` job pass `bash -n`.
- Both heredoc terminators sit at column 0 once YAML strips the block indent — the failure mode that would silently swallow the rest of the script.
- The caller's permission blocks grant everything the job now asks for, cross-checked programmatically, since a mismatch is a `startup_failure` rather than a visible error.

**The fallback path itself only executes on the next release** — it cannot be exercised here.
