### PR TITLE
release: v1.7.0 — confine the .env cascade, and let a project choose its route surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,122 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-30
+
+### Security
+- **A `Host:` header could make one project load another project's `.env`.**
+  `DomainResolver` matches the request host against the MACHINE-GLOBAL registry
+  (`HKM_USERDATA_DIR/projects.json`), which lists every project on the box by
+  absolute path — so a host owned by a *different* project resolved to that
+  project's directory, and tier 3 of the cascade read its `.env` with no check
+  that it was the application being served. The result was a foreign `APP_KEY`,
+  `DB_*` and `SESSION_*` spliced over ours, selected by a header the caller
+  controls; with `ENV_CACHE=1` the merged result — our secrets included — was
+  then written under *that* project's `var/cache`. Tier 3 is now confined to the
+  application root, and a refusal is announced via `error_log` rather than
+  silently skipped. The test is CONTAINMENT, not equality, because both layouts
+  are legitimate: flat, where the project path *is* the root, and nested, where
+  it is `<root>/projects/<name>`. Comparison is done after `realpath()` and with
+  an explicit separator on the prefix test, so a sibling sharing a name prefix
+  (`/srv/app-backup` against `/srv/app`) is not treated as inside. **When the
+  environment loads is unchanged** — still before `Kernel::build()`; only which
+  directory tier 3 will read has changed.
+
+### Added
+- **`routePolicy.only` — an allowlist for the routes your plugins publish.**
+  A plugin owns and declares its routes, and one `hkm plugins install` can add
+  thirty of them at once; the only existing control, `routePolicy.disable`,
+  SUBTRACTS, so it helps only once you already know a route exists. You cannot
+  veto what you were never shown. `Kernel::withRouteAllowPolicy()` (and
+  `proj.json` `"routePolicy": {"only": [...]}`) inverts it: when the list is
+  non-empty, a plugin route must match a spec or it is never exposed. Two
+  asymmetries are deliberate, both so the safer posture is not the harder one to
+  adopt — an EMPTY list means "no allowlist" rather than "allow nothing" (which
+  would empty an application on upgrade), and an allow spec matching nothing
+  does NOT fail the boot (naming routes from a plugin this deployment has not
+  enabled is normal in shared configuration), unlike a disable spec. Allow is
+  applied before disable, so the two compose: allow a module's whole domain,
+  then subtract the handful of its routes you do not want.
+- **Route-policy PREFIX specs — `"GET /mail/demo/*"`.** The exact form fails
+  OPEN on upgrade: veto five demo routes by exact key and the plugin's next
+  release adds a sixth, the five still match, the anti-typo guard is satisfied,
+  and the surface grows with nothing to announce it. A prefix keeps covering
+  what arrives later, which is the only form that survives a dependency bump.
+  Prefixes are method-specific (`GET /admin/*` does not silently also drop the
+  POST that mutates) and segment-bounded (`/mail/demo/*` never swallows
+  `/mail/demos`). Available to both `disable` and `only`; the exact and
+  module-domain forms are unchanged, and a prefix matching nothing still fails
+  the boot.
+- **`module.json` `"files"` — plain PHP files a module needs loaded.** A plugin
+  is loaded by the KERNEL, not by Composer: plugins are symlinked into
+  `plugins/` and reached through the PSR-4 `Plugins\` map, so no plugin's own
+  `composer.json` is ever read. That is fine for classes and fatal for
+  FUNCTIONS — a plugin declaring `"autoload": {"files": [...]}` has declared it
+  in the one place nothing looks, and nothing complains until something calls
+  one and dies with "Call to undefined function". Projects were hand-patching
+  this with a `require_once` in `bootstrap/app.php`, which works exactly once,
+  in the one project that noticed. Declared files are compiled into
+  `files-manifest.php` and required at boot; a declared file that does not exist
+  now FAILS THE BOOT instead of becoming a runtime fatal inside a plugin. When
+  `module.json` declares none, the module's own `composer.json`
+  `autoload.files` is honoured as a fallback — so existing plugins work with no
+  plugin change at all.
+
+### Fixed
+- **Plugin event listeners with dependencies were silently dropped.** The
+  `EventBus` is constructed once, at materialize, with the `CoreContainer`,
+  while listener DEPENDENCIES are bound per request by `Provider::register()`
+  into the `ModuleContainer`. Dispatch also gated resolution on `has()`, which
+  reports only what is EXPLICITLY BOUND — so an ordinary listener class was
+  reported absent and built with `new $listenerClass()`, which throws
+  `ArgumentCountError` for anything with constructor arguments, which the catch
+  logged as a failed listener. The event was dropped, the cause read like a bug
+  in the listener, and projects worked around it by hand-assembling listeners
+  (and four levels of a plugin's internals) into `withPorts()` so they would be
+  in the core container after all. `EventBus::forContainer()` now gives each
+  request and job a view that resolves against its own container, and dispatch
+  asks the container before falling back to `new`. Resolution is a strict
+  SUPERSET: a listener already bound in core resolves exactly as it did.
+- **`BOOT_CACHE` could silently skip a manifest a newer kernel added.** The
+  cached-boot check gated on one sentinel manifest, so a cache written by an
+  OLDER kernel — whose stamp still matches, because the builder inputs did not
+  change — was accepted while a manifest that version never compiled was simply
+  absent, and the stage reading it did nothing. The sentinel is now a list, so
+  an older cache invalidates and recompiles instead of leaving a new feature
+  inert until someone clears `var/cache` by hand. The route allowlist is also
+  part of the stamp key: without it, TIGHTENING the allowlist would leave the
+  previous, wider route manifest cached — the worst way for a security control
+  to fail.
+- **`route:list` gained `--unfiltered` and `--plugin`** (in the Commands
+  plugin): the inverse of `--filter`, and the one question an audit actually
+  asks — what did enabling these plugins expose with no filter in front of it?
+  An unfiltered route is not automatically unsafe (a login form, `robots.txt`,
+  or a page shell whose data sits behind a filtered endpoint are all
+  legitimately unfiltered); it is the set that has to be justified one by one.
+- **`hkm plugins enable` now reports the HTTP surface it activates** — how many
+  routes the plugin publishes and how many of those run no filter — instead of
+  reporting none of them.
+
+### Templates
+- Removed a duplicate `HashingPort` binding (the second silently overwrote the
+  first) and a dead `PdoDatabase` import.
+- The connection pool is no longer built and `warmup()`-ed at bootstrap. Under
+  PHP-FPM the bootstrap re-runs on EVERY request, so a pool there opened its
+  connections, served one request and was thrown away — strictly more expensive
+  than not pooling. It is now a lazy factory, gated on the CLI SAPI (which is
+  what OpenSwoole and the queue worker run under).
+- `app/worker/run.php` read `WORKER_QUEUE` and `WORKER_MAX_ITERATIONS` with
+  `getenv()`, which cannot see a `.env` value because the environment loader
+  deliberately skips `putenv()` — so both were silently ignored and every worker
+  drained `default`. Now `env()`.
+- `app/public/index.php` resolves the domain EXPLICITLY instead of reading the
+  `$domain` the bootstrap happened to leave in scope. `require` shares scope, so
+  the old form worked until the bootstrap returned early or renamed the
+  variable — at which point `ResolveStage` falls back to the RAW `Host` header
+  for `route_host`, the value the client controls. This matches what the
+  OpenSwoole entry point already had to do per request.
+- The process timezone is pinned explicitly (`APP_TIMEZONE`, default `UTC`).
+
 ## [1.6.1] - 2026-08-30
 
 ### Fixed

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -73,7 +73,7 @@ The other three (`phpshots/bind-it`, `phpshots/common-type-alias`,
 | Any plugin — behaviour, API, config | that plugin's own repository: `README.md`, `CLAUDE.md`, and `module.json` as the authority |
 | Which plugin claims a `solves` domain | `hkm plugins domains` — live, and never stale |
 | The `hkm` CLI, bundling, installers | [`tools/README.md`](../../tools/README.md), [`tools/docs/hkm-cli-usage.md`](../../tools/docs/hkm-cli-usage.md) |
-| Per-project frontend, `hkm ui`, surfaces | [`tools/src/templates/frontend/docs/HOW_IT_WORKS.md`](../../tools/src/templates/frontend/docs/HOW_IT_WORKS.md) |
+| Per-project frontend, `hkm ui`, surfaces | [`templates/frontend/docs/HOW_IT_WORKS.md`](../../templates/frontend/docs/HOW_IT_WORKS.md) |
 
 This is deliberate. A copy of someone else's documentation living in the kernel
 is the copy that goes stale, and it did: the catalogue this repo used to carry

--- a/projects/Bootstrap/EntryHelpers.php
+++ b/projects/Bootstrap/EntryHelpers.php
@@ -268,13 +268,51 @@ final class EntryHelpers
             return [];
         }
 
-        $disable = $data['routePolicy']['disable'] ?? $data['disable'] ?? null;
-        if (!is_array($disable)) {
+        return self::policySpecs($data['routePolicy']['disable'] ?? $data['disable'] ?? null);
+    }
+
+    /**
+     * Read the project's route ALLOWLIST from <projectPath>/proj.json under
+     * "routePolicy": { "only": [ ... ] }.
+     *
+     * The disable policy subtracts, so it only helps a project that already
+     * knows which routes a plugin publishes. This is the inverse — "expose
+     * nothing except these" — for a project that would rather state its HTTP
+     * surface than discover it. Passed to Kernel::withRouteAllowPolicy(); an
+     * empty/absent list means no allowlist, and every plugin route stays.
+     *
+     * @return list<string>
+     */
+    public static function projectRouteAllowPolicy(string $projectPath): array
+    {
+        $file = rtrim($projectPath, '/') . '/proj.json';
+        if (!is_file($file)) {
+            return [];
+        }
+
+        $data = json_decode((string) file_get_contents($file), true);
+        if (!is_array($data)) {
+            return [];
+        }
+
+        return self::policySpecs($data['routePolicy']['only'] ?? null);
+    }
+
+    /**
+     * Normalise a raw policy list: keep non-empty strings, trim them, drop
+     * anything malformed. Shared so "only" and "disable" cannot drift apart in
+     * what they accept.
+     *
+     * @return list<string>
+     */
+    private static function policySpecs(mixed $raw): array
+    {
+        if (!is_array($raw)) {
             return [];
         }
 
         $specs = [];
-        foreach ($disable as $spec) {
+        foreach ($raw as $spec) {
             if (is_string($spec) && trim($spec) !== '') {
                 $specs[] = trim($spec);
             }

--- a/projects/Bootstrap/Environment/LoadEnvironment.php
+++ b/projects/Bootstrap/Environment/LoadEnvironment.php
@@ -174,11 +174,60 @@ final class LoadEnvironment
         self::loadDomainTier($rootPath, $sld, $sub);
 
         // ── Tier 3: project overrides ───────────────────────────────────────
+        //
+        // CONFINED TO THE ROOT BEING SERVED — deliberately, and this is a
+        // security boundary, not tidiness.
+        //
+        // $domain comes from DomainResolver, which matches the request's Host
+        // header against the MACHINE-GLOBAL registry (HKM_USERDATA_DIR/
+        // projects.json) listing every project on the host by ABSOLUTE path. A
+        // Host owned by a DIFFERENT project therefore resolves to that
+        // project's directory — and loading its .env here would splice a
+        // foreign APP_KEY, DB_* and SESSION_* over ours, from a header the
+        // caller controls. With ENV_CACHE on, the merged result (our secrets
+        // included) is then written under that other project's var/cache.
+        //
+        // The test is containment rather than equality, because both layouts
+        // are legitimate: flat, where projectPath IS the root; and nested,
+        // where it is <root>/projects/<name>. Anything outside the root is a
+        // different application and its environment is none of our business.
         if ($domain !== null && !$domain->isPlatformOnly()) {
             $projectPath = rtrim($domain->projectPath, '/\\');
+
+            if (!self::isWithin($projectPath, $rootPath)) {
+                error_log(sprintf(
+                    "[hkm] Host '%s' is registered to project '%s' at %s, which is outside the "
+                    . 'application root %s. Its .env was NOT loaded. '
+                    . 'Check HKM_USERDATA_DIR/projects.json.',
+                    (string) $host,
+                    $domain->name,
+                    $projectPath,
+                    $rootPath,
+                ));
+
+                return;
+            }
+
             self::loadFile($projectPath . '/.env');
             self::loadDomainTier($projectPath, $sld, $sub);
         }
+    }
+
+    /**
+     * Is $path the same directory as $root, or somewhere beneath it?
+     *
+     * Compared after realpath() so symlinks and `..` cannot walk out, and with
+     * an explicit separator on the prefix test so a sibling directory sharing a
+     * name prefix (/srv/app-backup against /srv/app) is not treated as inside.
+     * A path that does not exist falls back to its normalised form: it can
+     * still be judged, and a non-existent directory has no .env to load anyway.
+     */
+    private static function isWithin(string $path, string $root): bool
+    {
+        $path = rtrim(realpath($path) ?: $path, '/\\');
+        $root = rtrim(realpath($root) ?: $root, '/\\');
+
+        return $path === $root || str_starts_with($path, $root . DIRECTORY_SEPARATOR);
     }
 
     /** Load the .env.{sld}, .env.{sub}, .env.{sub}.{sld} files under $path. */

--- a/src/Kernel/Boot/BootPipeline.php
+++ b/src/Kernel/Boot/BootPipeline.php
@@ -17,6 +17,8 @@ use AlfacodeTeam\PhpServicePlatform\Kernel\Boot\Stages\{
     CompileJobManifestStage,
     CompileCommandManifestStage,
     CompileConfigManifestStage,
+    CompileModuleFilesStage,
+    LoadModuleFilesStage,
     RegisterPortsStage,
     BindSecurityStage
 };
@@ -38,6 +40,20 @@ final class BootPipeline
      * @var list<BootStageContract>
      */
     private array $compileStages;
+
+    /**
+     * Stages that affect the PROCESS rather than a manifest, and so must run on
+     * every build even when the compilation is skipped. Loading a module's
+     * helper FILES defines global functions, which live in the process and not
+     * on disk: a cached boot that skipped them would leave BOOT_CACHE silently
+     * changing behaviour, surfacing as an undefined function deep inside a
+     * plugin. They run after the compilation that produces their manifest and
+     * before the validate stages, which are the first to touch live module
+     * objects; on a cached boot they run first of all.
+     *
+     * @var list<BootStageContract>
+     */
+    private array $alwaysStages;
 
     /**
      * Stages that VALIDATE live objects (port bindings, security layers). They
@@ -75,6 +91,14 @@ final class BootPipeline
         array $projectGroups = [],
         array $projectDomains = [],
         ?ManifestReader $reader = null,
+        /**
+         * Plugin-route ALLOWLIST (Kernel::withRouteAllowPolicy / proj.json
+         * routePolicy.only). Non-empty means a plugin route must match a spec or
+         * it is dropped; empty means no allowlist.
+         *
+         * @var list<string>
+         */
+        array $allowedRoutes = [],
     ) {
         // Single reader shared across every manifest-reading stage: each module.json
         // (the single source of truth) is read + JSON-decoded ONCE and cached, instead
@@ -88,17 +112,22 @@ final class BootPipeline
             new DetectConflictsStage($moduleClasses, reader: $reader),        // 2. no two modules share solves()
             new DetectCyclesStage($moduleClasses, reader: $reader),           // 3. no circular requires[] chains
             new CompileServiceManifestStage($moduleClasses, projectRoutes: $projectRoutes, reader: $reader, projectGroups: $projectGroups), // 4. dep graph → service-manifest.php
-            new CompileRouteManifestStage($moduleClasses, projectRoutes: $projectRoutes, disabledRoutes: $disabledRoutes, reader: $reader, projectGroups: $projectGroups, projectDomains: $projectDomains),   // 5. routes[] → route-manifest.php
+            new CompileRouteManifestStage($moduleClasses, projectRoutes: $projectRoutes, disabledRoutes: $disabledRoutes, reader: $reader, projectGroups: $projectGroups, projectDomains: $projectDomains, allowedRoutes: $allowedRoutes),   // 5. routes[] → route-manifest.php
             new CompileViewManifestStage($moduleClasses, reader: $reader),    // 6. views[] → view-manifest.php (project-first cascade)
             new CompileLangManifestStage($moduleClasses, reader: $reader),    // 7. lang[] → lang-manifest.php (project-first cascade)
             new CompileJobManifestStage($moduleClasses, reader: $reader),     // 8. jobs[] → job-manifest.php
             new CompileCommandManifestStage($moduleClasses, reader: $reader), // 9. commands[] → command-manifest.php
             new CompileConfigManifestStage($moduleClasses),                   // 10. config/*.php → config-manifest.php (project over plugin)
+            new CompileModuleFilesStage($moduleClasses, reader: $reader),     // 11. files[] / composer autoload.files → files-manifest.php
+        ];
+
+        $this->alwaysStages = [
+            new LoadModuleFilesStage(),                      // require_once module helper files
         ];
 
         $this->validateStages = [
-            new RegisterPortsStage($core),                   // 11. Port → Adapter bindings validated
-            new BindSecurityStage($securityLayers),          // 12. SecurityGateway layers validated
+            new RegisterPortsStage($core),                   // 12. Port → Adapter bindings validated
+            new BindSecurityStage($securityLayers),          // 13. SecurityGateway layers validated
         ];
     }
 
@@ -115,7 +144,9 @@ final class BootPipeline
      */
     public function run(): void
     {
-        $this->runStages([...$this->compileStages, ...$this->validateStages]);
+        // Compile first (it writes the manifest the always-stages read), then
+        // the process-level stages, then validation of the live objects.
+        $this->runStages([...$this->compileStages, ...$this->alwaysStages, ...$this->validateStages]);
     }
 
     /**
@@ -124,10 +155,14 @@ final class BootPipeline
      * Used when BootStamp reports the compiled manifests are already current: the
      * compilation is skipped, but a missing port binding or an unusable security
      * layer must still fail the boot.
+     *
+     * The always-stages run here too. Skipping them would mean BOOT_CACHE=1
+     * quietly stopped loading module helper files, so a flag documented as a
+     * pure optimisation would change what functions exist at runtime.
      */
     public function runValidationOnly(): void
     {
-        $this->runStages($this->validateStages);
+        $this->runStages([...$this->alwaysStages, ...$this->validateStages]);
     }
 
     /** @param list<BootStageContract> $stages */

--- a/src/Kernel/Boot/BootStamp.php
+++ b/src/Kernel/Boot/BootStamp.php
@@ -52,8 +52,21 @@ final class BootStamp
 {
     private const FILE = 'boot-stamp.php';
 
-    /** A manifest that must exist for a cached boot to be usable at all. */
-    private const SENTINEL = 'manifests/route-manifest.php';
+    /**
+     * Manifests that must ALL exist for a cached boot to be usable at all.
+     *
+     * More than one because the list also guards KERNEL UPGRADES. A cache
+     * written by an older kernel carries a stamp whose hash still matches (the
+     * builder inputs did not change), so it would be accepted — while a
+     * manifest that version never compiled is simply absent, and the stage
+     * reading it would quietly do nothing. Naming each manifest here makes an
+     * older cache fail the check and recompile, instead of the new feature
+     * being silently inert until someone clears var/cache by hand.
+     */
+    private const SENTINELS = [
+        'manifests/route-manifest.php',
+        'manifests/files-manifest.php',
+    ];
 
     /** Whether the compile may be skipped — `BOOT_CACHE` truthy. */
     public static function enabled(): bool
@@ -86,8 +99,10 @@ final class BootStamp
      */
     public static function read(string $configHash): ?array
     {
-        if (!is_file(Paths::cache(self::SENTINEL))) {
-            return null;
+        foreach (self::SENTINELS as $sentinel) {
+            if (!is_file(Paths::cache($sentinel))) {
+                return null;
+            }
         }
 
         $stamp = ManifestReader::readCompiled(self::FILE);

--- a/src/Kernel/Boot/Stages/CompileModuleFilesStage.php
+++ b/src/Kernel/Boot/Stages/CompileModuleFilesStage.php
@@ -1,0 +1,162 @@
+<?php declare(strict_types=1);
+
+namespace AlfacodeTeam\PhpServicePlatform\Kernel\Boot\Stages;
+
+use AlfacodeTeam\PhpServicePlatform\Kernel\Boot\{BootException, ManifestReader, ManifestWriter};
+
+/**
+ * Compiles the list of plain PHP FILES each module needs loaded — helper files
+ * that define global functions, which no class autoloader can ever reach.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * A plugin is loaded by the KERNEL, not by Composer: plugins are symlinked into
+ * `plugins/` and reached through the project's PSR-4 `Plugins\` map, so no
+ * plugin's own composer.json is ever read. That is fine for classes and fatal
+ * for functions — a plugin declaring
+ *
+ *     "autoload": { "files": ["Engine/functions.php"] }
+ *
+ * has declared it in the one place nothing looks. The functions are simply never
+ * defined, and PHP does not complain until something calls one, at which point
+ * it falls back to the global namespace and dies with
+ * "Call to undefined function ...". Projects have been hand-patching this with a
+ * `require_once` in bootstrap/app.php next to a comment explaining why — which
+ * works exactly once, in the one project that noticed.
+ *
+ * DECLARING FILES
+ * ---------------
+ * First-class, in module.json, alongside everything else the kernel reads:
+ *
+ *     { "files": ["Engine/functions.php"] }
+ *
+ * Paths are relative to the module directory (where Provider.php lives). A
+ * declared file that does not exist FAILS THE BOOT — it is a kernel contract,
+ * and the whole point is that a missing helper stops being a silent runtime
+ * fatal.
+ *
+ * COMPOSER FALLBACK
+ * -----------------
+ * When a module.json declares no `files`, the module's own composer.json
+ * `autoload.files` is used instead. Plugins already declare their helpers there
+ * correctly; honouring it means they work with no plugin change at all. Because
+ * composer.json is not the kernel's contract, a path listed there that does not
+ * exist is SKIPPED rather than failing the boot — the kernel is being generous
+ * with someone else's manifest, not enforcing it.
+ *
+ * Output (files-manifest.php): a flat, ordered list of absolute paths.
+ * {@see LoadModuleFilesStage} is what actually requires them, on every build,
+ * cached or not.
+ */
+final class CompileModuleFilesStage implements BootStageContract
+{
+    /** @param list<class-string> $moduleClasses */
+    public function __construct(
+        private readonly array $moduleClasses,
+        private readonly ManifestReader $reader = new ManifestReader(),
+    ) {}
+
+    public function run(): void
+    {
+        $files = [];
+
+        foreach ($this->moduleClasses as $moduleClass) {
+            $manifest = $this->reader->read($moduleClass);
+            $dir      = $this->moduleDir($moduleClass);
+
+            $declared = $manifest['files'] ?? null;
+
+            if (is_array($declared) && $declared !== []) {
+                foreach ($declared as $relative) {
+                    if (!is_string($relative) || trim($relative) === '') {
+                        throw new BootException(
+                            "module.json \"files\" for [{$moduleClass}] must contain non-empty strings, "
+                            . 'got ' . get_debug_type($relative) . '.'
+                        );
+                    }
+
+                    $path = $dir . '/' . ltrim($relative, '/');
+                    if (!is_file($path)) {
+                        throw new BootException(
+                            "module.json \"files\" for [{$moduleClass}] declares [{$relative}], "
+                            . "which does not exist at {$path}."
+                        );
+                    }
+
+                    $files[$this->key($path)] = $path;
+                }
+
+                continue;
+            }
+
+            // No explicit declaration — honour the module's own composer.json.
+            foreach ($this->composerFiles($dir) as $path) {
+                $files[$this->key($path)] = $path;
+            }
+        }
+
+        ManifestWriter::write('files-manifest.php', array_values($files));
+    }
+
+    /**
+     * `autoload.files` from the module's composer.json, resolved to absolute
+     * paths. Missing file, missing/invalid composer.json and a malformed
+     * `autoload.files` all yield nothing rather than failing: this is a
+     * best-effort read of a manifest the kernel does not own.
+     *
+     * @return list<string>
+     */
+    private function composerFiles(string $dir): array
+    {
+        $composer = $dir . '/composer.json';
+        if (!is_file($composer)) {
+            return [];
+        }
+
+        $raw     = file_get_contents($composer);
+        $decoded = $raw !== false ? json_decode($raw, true) : null;
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        $declared = $decoded['autoload']['files'] ?? null;
+        if (!is_array($declared)) {
+            return [];
+        }
+
+        $files = [];
+        foreach ($declared as $relative) {
+            if (!is_string($relative) || trim($relative) === '') {
+                continue;
+            }
+
+            $path = $dir . '/' . ltrim($relative, '/');
+            if (is_file($path)) {
+                $files[] = $path;
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * De-duplication key. Two modules living in the same directory (or one
+     * reachable by two paths) must not have their helpers required twice —
+     * require_once already guards that, but keeping the manifest itself clean
+     * means the list stays readable and its order stays meaningful.
+     */
+    private function key(string $path): string
+    {
+        return realpath($path) ?: $path;
+    }
+
+    private function moduleDir(string $moduleClass): string
+    {
+        $file = (new \ReflectionClass($moduleClass))->getFileName();
+        if ($file === false) {
+            throw new BootException("Cannot locate source file for [{$moduleClass}].");
+        }
+
+        return dirname($file);
+    }
+}

--- a/src/Kernel/Boot/Stages/CompileRouteManifestStage.php
+++ b/src/Kernel/Boot/Stages/CompileRouteManifestStage.php
@@ -60,6 +60,14 @@ final class CompileRouteManifestStage implements BootStageContract
          * @var list<string>
          */
         private readonly array $projectDomains = [],
+        /**
+         * ALLOWLIST of plugin routes — Kernel::withRouteAllowPolicy(). When
+         * non-empty, a plugin route must match a spec or it is dropped. Empty
+         * means "no allowlist", not "allow nothing".
+         *
+         * @var list<string>
+         */
+        private readonly array $allowedRoutes = [],
     ) {}
 
     public function run(): void
@@ -139,6 +147,9 @@ final class CompileRouteManifestStage implements BootStageContract
         // to add/remove). Dropping BEFORE project routes frees the "METHOD path"
         // key so a project may disable a plugin route AND declare its own on it
         // without a duplicate-route boot failure.
+        // Allowlist FIRST, then subtract. The two compose: allow a module's whole
+        // domain, then disable the handful of its routes you do not want.
+        $routes = $this->applyAllowPolicy($routes);
         $routes = $this->applyDisablePolicy($routes);
 
         // A disabled plugin route releases its name. Otherwise a project that
@@ -830,9 +841,9 @@ final class CompileRouteManifestStage implements BootStageContract
      * Drop plugin routes the project explicitly disabled, then verify every
      * disable spec matched at least one route — an unmatched spec is a typo or a
      * stale reference and fails the boot with a descriptive message (mirrors the
-     * unknown-requires-domain guard). Two spec forms, distinguished by shape:
-     *   - "METHOD /path"  → contains whitespace AND a "/path" part → exact route key
-     *   - "domain"        → anything else → every plugin route whose solves() matches
+     * unknown-requires-domain guard).
+     *
+     * Spec forms are shared with the allow policy — see {@see specMatches()}.
      *
      * @param array<string, array{module: ?class-string, solves: string, ...}> $routes
      * @return array<string, array<string, mixed>>
@@ -845,28 +856,12 @@ final class CompileRouteManifestStage implements BootStageContract
                 continue;
             }
 
-            $isRouteKey = str_contains($spec, ' ') && str_contains($spec, '/');
-            $matched    = 0;
+            $matched = 0;
 
-            if ($isRouteKey) {
-                // Normalize "get  /register" → "GET /register", and
-                // "get@organizer /x" → "GET@organizer /x" (the domain stays
-                // lower-case — only the HTTP method is upper-cased).
-                [$verb, $path] = preg_split('/\s+/', $spec, 2) ?: [$spec, ''];
-                $parsed = RouteIndex::parseKey($verb . ' ' . $path);
-                $key    = RouteIndex::key($parsed['method'], strtolower($parsed['domain']), $parsed['path']);
-
-                if (isset($routes[$key])) {
+            foreach ($routes as $key => $route) {
+                if ($this->specMatches($spec, $key, $route)) {
                     unset($routes[$key]);
-                    $matched = 1;
-                }
-            } else {
-                // Domain form — drop every plugin route that module solves().
-                foreach ($routes as $key => $route) {
-                    if (($route['solves'] ?? null) === $spec) {
-                        unset($routes[$key]);
-                        $matched++;
-                    }
+                    $matched++;
                 }
             }
 
@@ -881,6 +876,104 @@ final class CompileRouteManifestStage implements BootStageContract
         }
 
         return $routes;
+    }
+
+    /**
+     * Keep ONLY the plugin routes an allowlist names — "expose nothing except
+     * these" (Kernel::withRouteAllowPolicy / proj.json routePolicy.only).
+     *
+     * The disable policy subtracts, which requires the project to already know a
+     * route exists before it can refuse it. That is the wrong default when one
+     * `hkm plugins install` publishes thirty routes nobody reviewed. This is the
+     * inverse, for a project that would rather state its surface than chase it.
+     *
+     * An EMPTY allowlist means "no allowlist" and keeps every route. Treating it
+     * as "allow nothing" would turn a project that never opted in into an empty
+     * application on upgrade.
+     *
+     * Unmatched specs do NOT fail the boot here, unlike a disable spec. An
+     * allowlist that names routes from a plugin this deployment has not enabled
+     * is normal for shared/base configuration, and failing on it would make the
+     * safer posture the harder one to adopt.
+     *
+     * @param array<string, array{module: ?class-string, solves: string, ...}> $routes
+     * @return array<string, array<string, mixed>>
+     */
+    private function applyAllowPolicy(array $routes): array
+    {
+        if ($this->allowedRoutes === []) {
+            return $routes;
+        }
+
+        foreach ($routes as $key => $route) {
+            foreach ($this->allowedRoutes as $spec) {
+                if ($this->specMatches(trim($spec), $key, $route)) {
+                    continue 2;
+                }
+            }
+
+            unset($routes[$key]);
+        }
+
+        return $routes;
+    }
+
+    /**
+     * Does one policy spec match one compiled route? Three forms:
+     *
+     *   "METHOD /path"    exact route key
+     *   "METHOD /path/*"  every route under that path prefix, same method
+     *   "domain"          every route whose owning module solves() that domain
+     *
+     * The PREFIX form is what makes a policy survive a dependency bump. Listing
+     * five routes by exact key stays green when the plugin's next release adds a
+     * sixth: the five still match, so the anti-typo guard is satisfied, and the
+     * surface grew with nothing to announce it. A prefix keeps covering whatever
+     * arrives later.
+     *
+     * The method is compared too, so "GET /admin/*" does not silently also cover
+     * the POST that mutates. Use one spec per method when both are meant.
+     *
+     * @param array<string, mixed> $route
+     */
+    private function specMatches(string $spec, string $key, array $route): bool
+    {
+        // Domain form: no whitespace + no path part.
+        if (!str_contains($spec, ' ') || !str_contains($spec, '/')) {
+            return ($route['solves'] ?? null) === $spec;
+        }
+
+        // Normalize "get  /register" → "GET /register", and "get@organizer /x"
+        // → "GET@organizer /x" (the domain stays lower-case; only the HTTP
+        // method is upper-cased).
+        [$verb, $path] = preg_split('/\s+/', $spec, 2) ?: [$spec, ''];
+
+        if (!str_ends_with($path, '*')) {
+            $parsed = RouteIndex::parseKey($verb . ' ' . $path);
+
+            return $key === RouteIndex::key(
+                $parsed['method'],
+                strtolower($parsed['domain']),
+                $parsed['path'],
+            );
+        }
+
+        // Prefix form. Parse the wildcard away first so the method/domain are
+        // normalised exactly as the exact form does, then compare paths.
+        $stem   = rtrim(substr($path, 0, -1), '/');
+        $parsed = RouteIndex::parseKey($verb . ' ' . ($stem === '' ? '/' : $stem));
+        $actual = RouteIndex::parseKey($key);
+
+        if ($actual['method'] !== $parsed['method']
+            || strtolower($actual['domain']) !== strtolower($parsed['domain'])
+        ) {
+            return false;
+        }
+
+        // "/mail/demo/*" covers /mail/demo and everything beneath it, but never
+        // a sibling that merely shares the prefix as a substring (/mail/demos).
+        return $actual['path'] === $parsed['path']
+            || str_starts_with($actual['path'], $parsed['path'] . '/');
     }
 
     /**

--- a/src/Kernel/Boot/Stages/LoadModuleFilesStage.php
+++ b/src/Kernel/Boot/Stages/LoadModuleFilesStage.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace AlfacodeTeam\PhpServicePlatform\Kernel\Boot\Stages;
+
+use AlfacodeTeam\PhpServicePlatform\Kernel\Boot\ManifestReader;
+
+/**
+ * Requires every module helper file compiled by {@see CompileModuleFilesStage}.
+ *
+ * RUNS ON EVERY BUILD — cached or not.
+ * -------------------------------------
+ * This is the whole reason it is a separate stage from the compiler. Global
+ * FUNCTIONS live in the PHP process, not in a manifest on disk, so a boot that
+ * skips the compile phase because BOOT_CACHE says the manifests are current
+ * must still require the files. Folding this into the compile stage would mean
+ * that turning BOOT_CACHE on — an optimisation flag — silently stopped loading
+ * helper functions, and the failure would surface far away, as an undefined
+ * function inside a plugin.
+ *
+ * Reading the compiled list keeps the cached path cheap: one small manifest,
+ * instead of re-reading every module.json and composer.json to rediscover paths
+ * that have not changed.
+ *
+ * `require_once`, so an entry point that builds the kernel more than once in a
+ * process (tests, a Swoole worker re-reading config) redefines nothing.
+ */
+final class LoadModuleFilesStage implements BootStageContract
+{
+    public function run(): void
+    {
+        /** @var list<string> $files */
+        $files = ManifestReader::readCompiled('files-manifest.php');
+
+        foreach ($files as $file) {
+            // A path compiled on a previous boot can legitimately vanish — a
+            // plugin removed between deploys with a stale cache still on disk.
+            // Skipping keeps that a recoverable state: the next compile drops
+            // the entry. A file that is genuinely required and genuinely
+            // missing already failed at compile time, which is where a missing
+            // declared file is supposed to be caught.
+            if (is_string($file) && is_file($file)) {
+                require_once $file;
+            }
+        }
+    }
+}

--- a/src/Kernel/Events/EventBus.php
+++ b/src/Kernel/Events/EventBus.php
@@ -40,6 +40,37 @@ final class EventBus
     ) {}
 
     /**
+     * A view of this bus that resolves listeners from a REQUEST-SCOPED container.
+     *
+     * Subscriptions are app-lifetime — registered once, from Module::boot(),
+     * onto the instance in the CoreContainer. Listener DEPENDENCIES are not: a
+     * plugin binds them in Provider::register(), which runs per request against
+     * the ModuleContainer. A bus that only ever saw the CoreContainer therefore
+     * could not construct any listener with constructor arguments — has()
+     * returned false, dispatch fell through to `new $listenerClass()`, that
+     * threw ArgumentCountError, and the catch below logged it as a failed
+     * listener. The event was silently dropped, and projects worked around it
+     * by hand-assembling listeners (and their plugins' internals) into
+     * withPorts() so they would be in the core container after all.
+     *
+     * Resolution here is strictly a SUPERSET of before: ModuleContainer::make()
+     * consults its own bindings and then delegates to the CoreContainer, so a
+     * listener already bound in core resolves exactly as it did.
+     *
+     * Subscribers are copied by value, which is correct precisely because
+     * subscribe() only runs during materialize, before any request builds a
+     * view — a later subscription could not be seen, and there is no supported
+     * way to make one.
+     */
+    public function forContainer(ContainerInterface $container): self
+    {
+        $bus = new self($container, $this->logger);
+        $bus->subscribers = $this->subscribers;
+
+        return $bus;
+    }
+
+    /**
      * Subscribe a listener to an event. Called from Module::boot().
      *
      * @param class-string<EventListenerContract> $listenerClass
@@ -54,9 +85,7 @@ final class EventBus
     {
         foreach ($this->subscribers[$event->name()] ?? [] as $listenerClass) {
             try {
-                $listener = $this->container->has($listenerClass)
-                    ? $this->container->get($listenerClass)
-                    : new $listenerClass();
+                $listener = $this->resolveListener($listenerClass);
                 $listener->handle($event);
             } catch (\Throwable $e) {
                 // Isolate subscriber failures — never mask the original dispatch.
@@ -68,5 +97,39 @@ final class EventBus
                 ]);
             }
         }
+    }
+
+    /**
+     * Build a listener, preferring the container.
+     *
+     * This used to be gated on `has()`, and that gate was the bug. `has()`
+     * reports only what is EXPLICITLY BOUND — so an ordinary listener class,
+     * which no one binds by name because the container can autowire it, was
+     * reported absent and constructed with `new $listenerClass()`. That works
+     * for a listener with no constructor arguments and throws
+     * ArgumentCountError for every other one, which the caller catches and logs
+     * as "listener failed": a dropped event whose cause reads like a bug in the
+     * listener.
+     *
+     * Asking the container first lets it autowire the dependencies it knows
+     * about. `new` stays as the fallback for the case it was always right for —
+     * a dependency-free listener and a container that cannot resolve it —
+     * so nothing that worked before stops working.
+     *
+     * @param class-string $listenerClass
+     */
+    private function resolveListener(string $listenerClass): object
+    {
+        try {
+            $listener = $this->container->get($listenerClass);
+
+            if (is_object($listener)) {
+                return $listener;
+            }
+        } catch (\Throwable) {
+            // Not bound and not autowirable here — fall through.
+        }
+
+        return new $listenerClass();
     }
 }

--- a/src/Kernel/Kernel.php
+++ b/src/Kernel/Kernel.php
@@ -48,6 +48,8 @@ final class Kernel
     private array $projectRoutes = [];
     /** @var array<string, string> disable-spec => spec (de-duplicated, insertion order) */
     private array $disabledRoutes = [];
+    /** @var array<string, string> allow-spec => spec (empty = no allowlist) */
+    private array $allowedRoutes = [];
     /** @var array<string, mixed> project route groups + source-wide route defaults */
     private array $projectGroups = [];
     /** @var list<string> hosts this project serves (proj.json "domains") */
@@ -322,6 +324,16 @@ final class Kernel
      * matching nothing FAILS the build (no silent typos). Project routes declared
      * via withRoutes() are the project's own and are not affected.
      *
+     * A "METHOD /path" spec may end in `*` to disable a whole PREFIX:
+     *
+     *   ->withRoutePolicy(['GET /mail/demo/*'])   // every demo route, present and future
+     *
+     * The wildcard exists because the exact form fails OPEN on upgrade. Vetoing
+     * five demo routes by exact key stays green when the plugin's next release
+     * adds a sixth — the five still match, nothing errors, and the surface grew
+     * without anyone deciding to grow it. A prefix keeps covering what arrives
+     * later, which is the only form that survives a dependency bump.
+     *
      * Appends + de-duplicates; a base builder's disables carry into child projects.
      *
      * @param list<string> $disable
@@ -332,6 +344,50 @@ final class Kernel
             $spec = trim((string) $spec);
             if ($spec !== '') {
                 $this->disabledRoutes[$spec] = $spec;
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Declare an ALLOWLIST of plugin routes — "expose nothing except these".
+     *
+     * `withRoutePolicy()` subtracts, which means the project must already know a
+     * route exists in order to refuse it. That is the wrong default when a single
+     * `hkm plugins install` can publish thirty routes a project never reviewed:
+     * you cannot veto what you were never shown. This inverts it. When the list
+     * is non-empty, EVERY plugin route must match a spec or it is dropped.
+     *
+     *   ->withRouteAllowPolicy([
+     *       'POST /oauth/token',   // exact
+     *       'GET /oauth/jwks',
+     *       'auth.identity',       // an entire module domain
+     *       'GET /account/*',      // a prefix
+     *   ])
+     *
+     * Spec forms are identical to the disable policy: "METHOD /path", the same
+     * with a trailing `*`, or a bare module domain. An EMPTY list means "no
+     * allowlist" (every plugin route stays) rather than "allow nothing" — the
+     * silent alternative would be an empty application, and a project that wants
+     * no plugin HTTP surface says so by not enabling the plugins.
+     *
+     * Applied BEFORE the disable policy, so the two compose: allow a module's
+     * domain, then subtract the handful of its routes you do not want. Project
+     * routes from withRoutes() are the project's own and are never filtered.
+     *
+     * Unlike a disable spec, an allow spec that matches nothing does NOT fail the
+     * boot: an allowlist naming routes from a plugin this project has not enabled
+     * yet is a normal state for shared/base configuration, and failing there
+     * would make the safer posture the harder one to adopt.
+     *
+     * @param list<string> $only
+     */
+    public function withRouteAllowPolicy(array $only): self
+    {
+        foreach ($only as $spec) {
+            $spec = trim((string) $spec);
+            if ($spec !== '') {
+                $this->allowedRoutes[$spec] = $spec;
             }
         }
         return $this;
@@ -378,6 +434,7 @@ final class Kernel
             $this->projectGroups,
             $this->projectDomains,
             $reader,
+            array_values($this->allowedRoutes),
         );
 
         // BOOT CACHE (opt-in). Under PHP-FPM every request re-runs this method,
@@ -446,6 +503,11 @@ final class Kernel
             'routes'     => $this->projectRoutes,
             'groups'     => $this->projectGroups,
             'disabled'   => $this->disabledRoutes,
+            // Without this, tightening the allowlist would leave the previous,
+            // WIDER route manifest cached — the surface would stay exposed while
+            // the config said otherwise, which is the worst way for a security
+            // control to fail.
+            'allowed'    => $this->allowedRoutes,
             'domains'    => $this->projectDomains,
             'base'       => $this->basePath,
             'project'    => $this->projectPath,

--- a/src/Kernel/Loading/OnDemandLoader.php
+++ b/src/Kernel/Loading/OnDemandLoader.php
@@ -6,7 +6,7 @@ namespace AlfacodeTeam\PhpServicePlatform\Kernel\Loading;
 use AlfacodeTeam\PhpServicePlatform\Kernel\Container\{CoreContainer, ModuleContainer};
 use AlfacodeTeam\PhpServicePlatform\Kernel\Contracts\ModuleContract;
 use AlfacodeTeam\PhpServicePlatform\Kernel\Database\TransactionManager;
-use AlfacodeTeam\PhpServicePlatform\Kernel\Events\DomainEventCollector;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Events\{DomainEventCollector, EventBus};
 use AlfacodeTeam\PhpServicePlatform\Kernel\Exceptions\{CircularDependencyException, KernelException};
 use AlfacodeTeam\PhpServicePlatform\Kernel\Http\Request;
 use AlfacodeTeam\PhpServicePlatform\Kernel\Ports\DatabasePort;
@@ -85,6 +85,21 @@ final class OnDemandLoader
         $resolvedIdentity = $identity ?? Identity::guest();
         $container->singleton(Identity::class, static fn() => $resolvedIdentity);
         $container->singleton(DomainEventCollector::class, static fn() => new DomainEventCollector());
+
+        // The EventBus, rebound so listeners resolve against THIS request's
+        // container. The core instance owns the subscriptions; this view owns
+        // the lookup. Without it, a listener whose dependencies a plugin binds
+        // in register() can never be constructed, and the event is dropped with
+        // only a log line to show for it. Guarded because the bus is bound
+        // during materialize: a container built before that (or in a test that
+        // never materialized) simply keeps the core behaviour.
+        if ($this->core->has(EventBus::class)) {
+            $coreBus = $this->core->make(EventBus::class);
+            $container->singleton(
+                EventBus::class,
+                static fn($c): EventBus => $coreBus->forContainer($c),
+            );
+        }
         $container->singleton(
             TransactionManager::class,
             fn() => new TransactionManager($this->core->make(DatabasePort::class)),

--- a/templates/app/bootstrap/app.php
+++ b/templates/app/bootstrap/app.php
@@ -68,7 +68,6 @@ use Project\Bootstrap\Environment\ErrorGuard;
 use Project\Bootstrap\Environment\LoadEnvironment;
 use Project\Infrastructure\FileQueue;
 use Project\Infrastructure\InMemoryCache;
-use Project\Infrastructure\PdoDatabase;
 
 // Plugins — port adapters / infrastructure.
 use Plugins\Crypto\Infrastructure\AesEncrypter;
@@ -134,6 +133,16 @@ $env = static fn(string $key, ?string $default = null): ?string =>
     (($v = env($key)) !== null ? (string) $v : $default);
 
 // -----------------------------------------------------------------------------
+// TIMEZONE — pin the process to ONE basis, explicitly.
+// With date.timezone unset in php.ini, date() and DateTime fall back to UTC
+// while your database session may not, so a value written by PHP and a value
+// written by the DB can disagree by hours with nothing in the code to show it.
+// Pinning here makes date()/DateTime/gmdate() and the DB agree. Store UTC and
+// convert for display at the edge; override per deployment with APP_TIMEZONE.
+// -----------------------------------------------------------------------------
+date_default_timezone_set($env('APP_TIMEZONE', 'UTC') ?? 'UTC');
+
+// -----------------------------------------------------------------------------
 // STEP 5 — ENCRYPTION KEY (FAIL-FAST)
 // Collect the active key plus an optional previous key (kept during rotation so
 // data encrypted with the old key still decrypts). Order matters: the first key
@@ -170,11 +179,18 @@ if ($appKeys === [] && !in_array($appEnv, ['local', 'testing'], true)) {
 $ports = [
     CachePort::class => static fn(): InMemoryCache => new InMemoryCache(),
 
-     DatabasePort::class => static fn(): MultiDriverDatabaseAdapter =>
+    // Central/default connection. The Database PLUGIN binds its own, better
+    // configured DatabasePort (logger + query log + pool) into the request
+    // container when a route pulls database.management into its graph — and a
+    // module binding WINS over this one (ModuleContainer::make consults its own
+    // bindings before delegating to the core container). This binding therefore
+    // serves the paths the graph does not reach: CLI commands, the worker, and
+    // anything resolving from the CoreContainer (EventBus listeners, the outbox
+    // relay). Keep the two configured the same way, or those paths will quietly
+    // behave differently from HTTP.
+    DatabasePort::class => static fn(): MultiDriverDatabaseAdapter =>
         new MultiDriverDatabaseAdapter((new DatabaseConfigurationFactory())->fromEnvironment()),
-    HashingPort::class => static fn(): PasswordHasher => new PasswordHasher(
-        cost: (int) ($env('HASH_BCRYPT_COST', '12') ?? '12'),
-    ),
+
     HashingPort::class => static fn(): PasswordHasher => new PasswordHasher(
         cost: (int) ($env('HASH_BCRYPT_COST', '12') ?? '12'),
     ),
@@ -199,19 +215,40 @@ $ports = [
     //       ),
 ];
 
-if (filter_var($env('DB_POOL_ENABLED', 'false'), FILTER_VALIDATE_BOOL)) {
-    $dbConfig = (new DatabaseConfigurationFactory())->fromEnvironment();
+// -----------------------------------------------------------------------------
+// CONNECTION POOL (long-lived runtimes only)
+// A pool is only ever a win in a process that serves MANY requests: OpenSwoole
+// workers, and the queue worker. Under PHP-FPM this whole file re-executes on
+// EVERY request, so a pool built here would open its connections, serve one
+// request and be thrown away — strictly more expensive than not pooling at all.
+//
+// `php_sapi_name()` is the honest test: 'cli' covers the worker and console,
+// and OpenSwoole servers also run under the CLI SAPI. PHP-FPM ('fpm-fcgi') and
+// mod_php ('apache2handler') are excluded, which is the point.
+//
+// Note the pool is registered as a LAZY factory, not a pre-built object: even
+// in a long-lived process nothing connects until something first resolves it,
+// and warmup() then happens once, inside that process, rather than at boot.
+// -----------------------------------------------------------------------------
+if (filter_var($env('DB_POOL_ENABLED', 'false'), FILTER_VALIDATE_BOOL)
+    && PHP_SAPI === 'cli'
+) {
     $logQueries = filter_var($env('DB_ENABLE_QUERY_LOG', 'false'), FILTER_VALIDATE_BOOL);
 
-    $pool = new ConnectionPool(
-        factory: static fn(): MultiDriverDatabaseAdapter =>
-        new MultiDriverDatabaseAdapter($dbConfig, null, $logQueries),
-        config: PoolConfiguration::fromEnvironment(),
-        driver: $dbConfig->driver(),
-    );
-    $pool->warmup();
+    $ports[ConnectionPool::class] = static function () use ($logQueries): ConnectionPool {
+        // Built inside the factory so an unused pool never even reads the env.
+        $dbConfig = (new DatabaseConfigurationFactory())->fromEnvironment();
 
-    $ports[ConnectionPool::class] = $pool;
+        $pool = new ConnectionPool(
+            factory: static fn(): MultiDriverDatabaseAdapter =>
+                new MultiDriverDatabaseAdapter($dbConfig, null, $logQueries),
+            config: PoolConfiguration::fromEnvironment(),
+            driver: $dbConfig->driver(),
+        );
+        $pool->warmup();
+
+        return $pool;
+    };
 }
 
 
@@ -250,6 +287,14 @@ return Kernel::configure()
     // module domain) without forking the plugin. Applied to plugin routes before
     // project routes compile — an unmatched spec fails the boot.
     ->withRoutePolicy(EntryHelpers::projectRoutePolicy($projectRoot))
+
+    // Project ROUTE ALLOWLIST from proj.json ("routePolicy": {"only": [...]}).
+    // The disable policy above SUBTRACTS, which only helps once you already know
+    // a route exists — and one `hkm plugins install` can publish thirty. This is
+    // the inverse: when the list is non-empty, a plugin route must match a spec
+    // or it is never exposed. Empty means "no allowlist" (everything stays).
+    // See what your plugins publish: `hkm route:list --unfiltered --plugin`.
+    ->withRouteAllowPolicy(EntryHelpers::projectRouteAllowPolicy($projectRoot))
 
     // Security layers run BEFORE any module loads — a denied request costs zero
     // module work. CsrfTokenLayer here is a stateless, HMAC-signed token

--- a/templates/app/public/index.php
+++ b/templates/app/public/index.php
@@ -34,18 +34,33 @@ psp_require_kernel_autoload();
 
 use AlfacodeTeam\PhpServicePlatform\Kernel\Http\Request;
 use AlfacodeTeam\PhpServicePlatform\Kernel\Http\Response;
+use Project\Bootstrap\EntryHelpers;
 
-// 2. Build the application. $domain (the resolved DomainContext, possibly null)
-//    is defined inside the bootstrap and is in scope after this require.
+// 2. Build the application.
 /** @var \AlfacodeTeam\PhpServicePlatform\Kernel\Kernel $kernel */
 $kernel = require __DIR__ . '/../bootstrap/app.php';
 
+// 3. Resolve the domain EXPLICITLY, rather than reading the $domain that the
+//    bootstrap happens to leave behind in this scope.
+//
+//    `require` shares variable scope, so the old version worked — right up
+//    until the bootstrap returned early, renamed the variable, or wrapped its
+//    body in a function. Then `isset($domain)` is simply false, the attributes
+//    below are never attached, and ResolveStage falls back to the RAW Host
+//    header for route_host. That fallback is the one the client controls, so a
+//    refactor two files away could silently hand route-table selection to the
+//    caller. An explicit call cannot fail that way.
+//
+//    It costs nothing: DomainResolver caches the parsed registry statically per
+//    process, so this second call reads no files.
+$domain = EntryHelpers::resolveDomain(dirname(__DIR__, 2), $_SERVER['HTTP_HOST'] ?? null);
+
 try {
-    // 3. Build an immutable Request from the SAPI globals ($_SERVER, $_GET,
+    // 4. Build an immutable Request from the SAPI globals ($_SERVER, $_GET,
     //    $_POST, php://input, ...) and ride the resolved domain on it as an
     //    attribute (never via a global — coroutine/Swoole safe).
     $request = Request::capture();
-    if (isset($domain) && $domain !== null) {
+    if ($domain !== null) {
         $request = $request
             ->withAttribute('domain', $domain)
             // The FACE (admin/api/project/public) and the HOST let a route declare

--- a/templates/app/worker/run.php
+++ b/templates/app/worker/run.php
@@ -52,8 +52,13 @@ use AlfacodeTeam\PhpServicePlatform\Kernel\Ports\QueuePort;
 $kernel = require __DIR__ . '/../bootstrap/app.php';
 
 // 3. Read which queue to drain and how many jobs to process before exiting.
-$queue         = (string) (getenv('WORKER_QUEUE') ?: 'default');
-$maxIterations = (int) (getenv('WORKER_MAX_ITERATIONS') ?: 0);
+//    env(), NOT getenv(): LoadEnvironment injects .env into $_ENV/$_SERVER and
+//    deliberately does not call putenv() (it is the injection bottleneck and is
+//    coroutine-unsafe), so getenv() cannot see a .env value. Using it here meant
+//    WORKER_QUEUE in .env was silently ignored and every worker drained
+//    'default' — the wrong queue, with no error to say so.
+$queue         = (string) (env('WORKER_QUEUE') ?: 'default');
+$maxIterations = (int) (env('WORKER_MAX_ITERATIONS') ?: 0);
 
 // 4. The kernel's worker loop — materialises the Worker pipeline on first call.
 //

--- a/templates/plugin/module.json
+++ b/templates/plugin/module.json
@@ -11,6 +11,9 @@
     "emits": [],
     "listens": [],
 
+    "//files": "Plain PHP files to require at boot — helper files defining GLOBAL FUNCTIONS, which no class autoloader can reach. Paths are relative to this directory. A declared file that does not exist fails the boot. Omit this key and the kernel falls back to your composer.json autoload.files.",
+    "files": [],
+
     "documentation": "The {{STUDLY}} plugin. Describe its single business domain here — this text is shown as a comment when the plugin is enabled into a project. Enabling publishes its config/, database/ (migrations, seeders, factories) and resources/ into the project; disabling can unpublish them and roll back its migrations.",
 
     "config": []

--- a/templates/proj.json
+++ b/templates/proj.json
@@ -5,7 +5,8 @@
     "features": [],
     "views": "resources",
     "essentials": [],
-    "routePolicy": { "disable": [] },
+    "//routePolicy": "Your control over the routes your PLUGINS publish. only[] is an ALLOWLIST (expose nothing except these); disable[] SUBTRACTS. Spec forms: \"METHOD /path\", \"METHOD /path/*\" (prefix — keeps covering routes a plugin adds in a later release), or a bare module domain. Audit with: hkm route:list --unfiltered --plugin",
+    "routePolicy": { "only": [], "disable": [] },
     "routes": [
         { "method": "GET", "path": "/",     "handler": "{{STUDLY}}\\Infrastructure\\Http\\HomeController@index" },
         { "method": "GET", "path": "/ping", "handler": "{{STUDLY}}\\Infrastructure\\Http\\HomeController@ping"  }

--- a/templates/simple/app/bootstrap/app.php
+++ b/templates/simple/app/bootstrap/app.php
@@ -127,7 +127,10 @@ return Kernel::configure()
     //     hkm plugins install database     // pooled multi-driver adapter
     //     hkm plugins install redis-cache  // Redis CachePort + QueuePort
     //
-    // Installing either one rewrites the binding below to use it.
+    // Installing one wires its Provider into withModules()/withEssentialModules()
+    // below, but it does NOT touch this array: `hkm plugins` never edits port
+    // bindings. Replacing the binding below is a manual step, and the plugin's
+    // own README says which adapter and constructor to use.
     ->withPorts([
         // Lazy: the closure runs on FIRST USE, not at boot. A project with no
         // database configured therefore boots and serves normally, and only a
@@ -163,6 +166,14 @@ return Kernel::configure()
     // A project can also switch OFF a route a plugin declares, without forking
     // the plugin: proj.json "routePolicy": { "disable": ["GET /register"] }.
     ->withRoutePolicy(EntryHelpers::projectRoutePolicy($projectRoot))
+
+    // Project ROUTE ALLOWLIST from proj.json ("routePolicy": {"only": [...]}).
+    // The disable policy above SUBTRACTS, which only helps once you already know
+    // a route exists — and one `hkm plugins install` can publish thirty. This is
+    // the inverse: when the list is non-empty, a plugin route must match a spec
+    // or it is never exposed. Empty means "no allowlist" (everything stays).
+    // See what your plugins publish: `hkm route:list --unfiltered --plugin`.
+    ->withRouteAllowPolicy(EntryHelpers::projectRouteAllowPolicy($projectRoot))
 
     ->withSecurity([
         // The only security layer the kernel ships: stateless HMAC-signed CSRF

--- a/tests/Fixtures/ComposerFilesModule/Engine/functions.php
+++ b/tests/Fixtures/ComposerFilesModule/Engine/functions.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+// Mirrors hkm-plugin-authorization: helpers live at Engine/functions.php and are
+// declared ONLY in the plugin's composer.json autoload.files.
+if (!function_exists('psp_test_composer_helper')) {
+    function psp_test_composer_helper(): string
+    {
+        return 'composer';
+    }
+}

--- a/tests/Fixtures/ComposerFilesModule/Provider.php
+++ b/tests/Fixtures/ComposerFilesModule/Provider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\ComposerFilesModule;
+
+/**
+ * Fixture: a module that declares NOTHING in module.json and instead relies on
+ * its own composer.json `autoload.files` — the real shape of every plugin
+ * written before the kernel had a `files` key. Composer never processes it
+ * (plugins are symlinked and reached through the PSR-4 Plugins\ map), so the
+ * kernel honouring it is what makes those plugins work unchanged.
+ */
+final class Provider
+{
+}

--- a/tests/Fixtures/ComposerFilesModule/composer.json
+++ b/tests/Fixtures/ComposerFilesModule/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "fixture/composer-files",
+    "autoload": {
+        "psr-4": { "Tests\\Fixtures\\ComposerFilesModule\\": "" },
+        "files": ["Engine/functions.php", "Engine/does-not-exist.php"]
+    }
+}

--- a/tests/Fixtures/ComposerFilesModule/module.json
+++ b/tests/Fixtures/ComposerFilesModule/module.json
@@ -1,0 +1,9 @@
+{
+    "name": "composerfiles",
+    "version": "1.0.0",
+    "solves": "composerfiles.fixture",
+    "type": "module",
+    "requires": [],
+    "exposes": [],
+    "config": []
+}

--- a/tests/Fixtures/FilesModule/Provider.php
+++ b/tests/Fixtures/FilesModule/Provider.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\FilesModule;
+
+/**
+ * Fixture: a module that declares helper files EXPLICITLY in module.json.
+ * ManifestReader locates module.json by reflecting on the Provider's file, so
+ * the class has to be real and sit beside a real module.json.
+ */
+final class Provider
+{
+}

--- a/tests/Fixtures/FilesModule/helpers.php
+++ b/tests/Fixtures/FilesModule/helpers.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+// A GLOBAL function — the thing no class autoloader can ever reach, and the
+// whole reason CompileModuleFilesStage exists.
+if (!function_exists('psp_test_declared_helper')) {
+    function psp_test_declared_helper(): string
+    {
+        return 'declared';
+    }
+}

--- a/tests/Fixtures/FilesModule/module.json
+++ b/tests/Fixtures/FilesModule/module.json
@@ -1,0 +1,10 @@
+{
+    "name": "files",
+    "version": "1.0.0",
+    "solves": "files.fixture",
+    "type": "module",
+    "requires": [],
+    "exposes": [],
+    "files": ["helpers.php"],
+    "config": []
+}

--- a/tests/Unit/Kernel/Boot/BootStampTest.php
+++ b/tests/Unit/Kernel/Boot/BootStampTest.php
@@ -36,8 +36,13 @@ final class BootStampTest extends TestCase
 
         $this->previousEnv = $_ENV['BOOT_CACHE'] ?? false;
 
-        // A compiled manifest must exist for a cached boot to be usable at all.
+        // EVERY sentinel manifest must exist for a cached boot to be usable at
+        // all — see BootStamp::SENTINELS. Writing them all here keeps this
+        // fixture honest about what a real compiled cache contains; a cache
+        // missing any one of them is the upgrade case, covered separately by
+        // test_a_missing_compiled_manifest_misses().
         ManifestWriter::write('route-manifest.php', ['GET /' => ['handler' => 'C@m']]);
+        ManifestWriter::write('files-manifest.php', []);
     }
 
     protected function tearDown(): void
@@ -190,6 +195,19 @@ final class BootStampTest extends TestCase
         // cleared by a deploy. Never serve from a cache with nothing behind it.
         BootStamp::write($this->hash(), [], []);
         unlink(Paths::cache('manifests/route-manifest.php'));
+
+        self::assertNull(BootStamp::read($this->hash()));
+    }
+
+    public function test_a_cache_from_a_kernel_that_predates_a_manifest_misses(): void
+    {
+        // The upgrade case. An older kernel wrote a perfectly valid stamp and
+        // every manifest IT knew about; this kernel added another. The builder
+        // inputs did not change, so the hash still matches and the stamp is
+        // accepted — while the stage reading the new manifest finds nothing and
+        // silently does no work. Only the manifest's own absence can catch it.
+        BootStamp::write($this->hash(), [], []);
+        unlink(Paths::cache('manifests/files-manifest.php'));
 
         self::assertNull(BootStamp::read($this->hash()));
     }

--- a/tests/Unit/Kernel/Boot/ModuleFilesStageTest.php
+++ b/tests/Unit/Kernel/Boot/ModuleFilesStageTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Kernel\Boot;
+
+use AlfacodeTeam\PhpServicePlatform\Kernel\Boot\BootException;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Boot\ManifestReader;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Boot\Stages\CompileModuleFilesStage;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Boot\Stages\LoadModuleFilesStage;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Support\Paths;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\ComposerFilesModule\Provider as ComposerFilesProvider;
+use Tests\Fixtures\FilesModule\Provider as FilesProvider;
+
+/**
+ * Module helper FILES — the plain PHP files that define global functions.
+ *
+ * A plugin is loaded by the kernel, not by Composer: plugins are symlinked into
+ * `plugins/` and reached through the PSR-4 `Plugins\` map, so no plugin's own
+ * composer.json is ever read. Classes are fine; functions are not. A plugin
+ * declaring `autoload.files` has declared it in the one place nothing looks, and
+ * nothing complains until something calls the function and dies with
+ * "Call to undefined function".
+ */
+#[CoversClass(CompileModuleFilesStage::class)]
+#[CoversClass(LoadModuleFilesStage::class)]
+final class ModuleFilesStageTest extends TestCase
+{
+    private string $root;
+    private ?string $previousProject = null;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/hkm-modulefiles-' . bin2hex(random_bytes(6));
+        mkdir($this->root . '/var/cache/manifests', 0775, true);
+
+        $this->previousProject = Paths::project();
+        Paths::setProject($this->root);
+    }
+
+    protected function tearDown(): void
+    {
+        Paths::setProject($this->previousProject);
+        $this->deleteTree($this->root);
+    }
+
+    public function test_it_compiles_files_declared_in_module_json(): void
+    {
+        (new CompileModuleFilesStage([FilesProvider::class]))->run();
+
+        $compiled = ManifestReader::readCompiled('files-manifest.php');
+
+        self::assertCount(1, $compiled);
+        self::assertStringEndsWith('tests/Fixtures/FilesModule/helpers.php', $compiled[0]);
+    }
+
+    public function test_it_falls_back_to_the_modules_own_composer_autoload_files(): void
+    {
+        // The case every existing plugin is in: helpers declared correctly, in
+        // composer.json, which the kernel's loader never reads. Honouring it
+        // means those plugins work with no plugin change at all.
+        (new CompileModuleFilesStage([ComposerFilesProvider::class]))->run();
+
+        $compiled = ManifestReader::readCompiled('files-manifest.php');
+
+        self::assertCount(1, $compiled, 'the non-existent composer entry must be skipped, not compiled');
+        self::assertStringEndsWith('ComposerFilesModule/Engine/functions.php', $compiled[0]);
+    }
+
+    public function test_module_json_takes_precedence_over_composer_json(): void
+    {
+        // module.json is the kernel's contract and the single source of truth.
+        // A module declaring both must not get composer's list appended to it,
+        // or removing an entry from module.json would silently do nothing.
+        (new CompileModuleFilesStage([FilesProvider::class, ComposerFilesProvider::class]))->run();
+
+        $compiled = ManifestReader::readCompiled('files-manifest.php');
+
+        self::assertCount(2, $compiled);
+    }
+
+    public function test_a_declared_file_that_does_not_exist_fails_the_boot(): void
+    {
+        // The entire point: a missing helper must stop being a silent runtime
+        // fatal in a plugin and become a loud, located boot failure.
+        $module = $this->fixtureModule(['files' => ['nope.php']]);
+
+        $this->expectException(BootException::class);
+        $this->expectExceptionMessageMatches('/nope\.php/');
+
+        (new CompileModuleFilesStage([$module]))->run();
+    }
+
+    public function test_a_non_string_files_entry_fails_the_boot(): void
+    {
+        $module = $this->fixtureModule(['files' => [42]]);
+
+        $this->expectException(BootException::class);
+        $this->expectExceptionMessageMatches('/non-empty strings/');
+
+        (new CompileModuleFilesStage([$module]))->run();
+    }
+
+    public function test_the_loader_actually_defines_the_global_functions(): void
+    {
+        // Compiling a list proves nothing on its own — the functions have to end
+        // up defined in the process, which is the only thing callers care about.
+        self::assertFalse(function_exists('psp_test_declared_helper'));
+        self::assertFalse(function_exists('psp_test_composer_helper'));
+
+        (new CompileModuleFilesStage([FilesProvider::class, ComposerFilesProvider::class]))->run();
+        (new LoadModuleFilesStage())->run();
+
+        self::assertTrue(function_exists('psp_test_declared_helper'));
+        self::assertTrue(function_exists('psp_test_composer_helper'));
+        self::assertSame('declared', psp_test_declared_helper());
+        self::assertSame('composer', psp_test_composer_helper());
+    }
+
+    public function test_the_loader_is_idempotent(): void
+    {
+        // build() can run more than once in a process (tests, a Swoole worker
+        // rebuilding). A second require of a file defining functions would be a
+        // fatal redeclare, so this must stay require_once.
+        (new CompileModuleFilesStage([FilesProvider::class]))->run();
+
+        (new LoadModuleFilesStage())->run();
+        (new LoadModuleFilesStage())->run();
+
+        self::assertTrue(function_exists('psp_test_declared_helper'));
+    }
+
+    public function test_the_loader_tolerates_a_path_that_vanished(): void
+    {
+        // A stale cache naming a plugin removed between deploys. Skipping keeps
+        // that recoverable; the next compile drops the entry.
+        $missing = $this->root . '/gone.php';
+        \AlfacodeTeam\PhpServicePlatform\Kernel\Boot\ManifestWriter::write('files-manifest.php', [$missing]);
+
+        (new LoadModuleFilesStage())->run();
+
+        $this->addToAssertionCount(1); // reaching here without a fatal is the assertion
+    }
+
+    public function test_a_module_declaring_nothing_anywhere_contributes_nothing(): void
+    {
+        $module = $this->fixtureModule([]);
+
+        (new CompileModuleFilesStage([$module]))->run();
+
+        self::assertSame([], ManifestReader::readCompiled('files-manifest.php'));
+    }
+
+    /**
+     * Build a throwaway module (Provider class + module.json) on disk and return
+     * its class-string. ManifestReader finds module.json by reflecting on the
+     * Provider's file, so both have to be real and adjacent.
+     *
+     * @param  array<string, mixed> $manifest extra module.json keys
+     * @return class-string
+     */
+    private function fixtureModule(array $manifest): string
+    {
+        $name  = 'Fx' . bin2hex(random_bytes(6));
+        $dir   = $this->root . '/modules/' . $name;
+        mkdir($dir, 0775, true);
+
+        file_put_contents($dir . '/module.json', json_encode([
+            'name'     => strtolower($name),
+            'version'  => '1.0.0',
+            'solves'   => strtolower($name) . '.fixture',
+            'type'     => 'module',
+            'requires' => [],
+            'exposes'  => [],
+            'config'   => [],
+        ] + $manifest, JSON_THROW_ON_ERROR));
+
+        $class = 'PspFixture\\' . $name . '\\Provider';
+        file_put_contents(
+            $dir . '/Provider.php',
+            "<?php\nnamespace PspFixture\\{$name};\nfinal class Provider {}\n"
+        );
+        require_once $dir . '/Provider.php';
+
+        /** @var class-string $class */
+        return $class;
+    }
+
+    private function deleteTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Unit/Kernel/Boot/RoutePolicyTest.php
+++ b/tests/Unit/Kernel/Boot/RoutePolicyTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Kernel\Boot;
+
+use AlfacodeTeam\PhpServicePlatform\Kernel\Boot\BootException;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Boot\ManifestReader;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Boot\Stages\CompileRouteManifestStage;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Support\Paths;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The project's control over the routes its PLUGINS publish.
+ *
+ * A plugin owns and declares its routes, and one `hkm plugins install` can add
+ * thirty of them. The project deploying it is the final authority on what is
+ * actually exposed — but only if it can express that. These cover both verbs:
+ * `disable` (subtract) and `only` (allowlist).
+ */
+#[CoversClass(CompileRouteManifestStage::class)]
+final class RoutePolicyTest extends TestCase
+{
+    private string $root;
+    private ?string $previousProject = null;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/hkm-routepolicy-' . bin2hex(random_bytes(6));
+        mkdir($this->root . '/var/cache/manifests', 0775, true);
+
+        $this->previousProject = Paths::project();
+        Paths::setProject($this->root);
+    }
+
+    protected function tearDown(): void
+    {
+        Paths::setProject($this->previousProject);
+        $this->deleteTree($this->root);
+    }
+
+    /**
+     * A throwaway plugin whose module.json declares the given routes.
+     *
+     * @param list<array<string, mixed>> $routes
+     * @return class-string
+     */
+    private function plugin(string $solves, array $routes): string
+    {
+        $name = 'Px' . bin2hex(random_bytes(6));
+        $dir  = $this->root . '/plugins/' . $name;
+        mkdir($dir, 0775, true);
+
+        file_put_contents($dir . '/module.json', json_encode([
+            'name'     => strtolower($name),
+            'version'  => '1.0.0',
+            'solves'   => $solves,
+            'type'     => 'module',
+            'requires' => [],
+            'exposes'  => [],
+            'config'   => [],
+            'routes'   => $routes,
+        ], JSON_THROW_ON_ERROR));
+
+        file_put_contents(
+            $dir . '/Provider.php',
+            "<?php\nnamespace PspRoutePolicy\\{$name};\nfinal class Provider {}\n"
+        );
+        require_once $dir . '/Provider.php';
+
+        /** @var class-string */
+        return 'PspRoutePolicy\\' . $name . '\\Provider';
+    }
+
+    /** The mail plugin's demo routes — the case that motivated the prefix form. */
+    private function mailDemoPlugin(bool $withSixth = false): string
+    {
+        $routes = [
+            ['method' => 'GET', 'path' => '/mail/demo', 'handler' => 'C@index'],
+            ['method' => 'GET', 'path' => '/mail/demo/send', 'handler' => 'C@send'],
+            ['method' => 'GET', 'path' => '/mail/demo/queue', 'handler' => 'C@queue'],
+            ['method' => 'GET', 'path' => '/mail/demo/preview', 'handler' => 'C@preview'],
+            ['method' => 'GET', 'path' => '/mail/demo/view', 'handler' => 'C@view'],
+            ['method' => 'GET', 'path' => '/mail/status', 'handler' => 'C@status'],
+        ];
+
+        if ($withSixth) {
+            // What a plugin UPGRADE looks like: one more demo route appears.
+            $routes[] = ['method' => 'GET', 'path' => '/mail/demo/blast', 'handler' => 'C@blast'];
+        }
+
+        return $this->plugin('mail.delivery', $routes);
+    }
+
+    /** @return array<string, mixed> the compiled manifest */
+    private function compile(array $modules, array $disable = [], array $only = []): array
+    {
+        (new CompileRouteManifestStage(
+            $modules,
+            disabledRoutes: $disable,
+            reader: new ManifestReader(),
+            allowedRoutes: $only,
+        ))->run();
+
+        return ManifestReader::readCompiled('route-manifest.php');
+    }
+
+    // ── disable: the prefix form ─────────────────────────────────────────────
+
+    public function test_a_prefix_disable_drops_the_whole_subtree(): void
+    {
+        $manifest = $this->compile([$this->mailDemoPlugin()], disable: ['GET /mail/demo/*']);
+
+        self::assertArrayNotHasKey('GET /mail/demo/send', $manifest);
+        self::assertArrayNotHasKey('GET /mail/demo/queue', $manifest);
+        self::assertArrayNotHasKey('GET /mail/demo/preview', $manifest);
+        self::assertArrayNotHasKey('GET /mail/demo/view', $manifest);
+        self::assertArrayNotHasKey('GET /mail/demo', $manifest, 'the stem itself is covered');
+
+        self::assertArrayHasKey('GET /mail/status', $manifest, 'a sibling must survive');
+    }
+
+    public function test_a_prefix_disable_still_covers_a_route_added_by_a_plugin_upgrade(): void
+    {
+        // THE REASON THE PREFIX FORM EXISTS. Listing the five demo routes by
+        // exact key stays green when the plugin's next release adds a sixth:
+        // the five still match, the anti-typo guard is satisfied, and the
+        // surface silently grew. Show both halves.
+        $exact = [
+            'GET /mail/demo',
+            'GET /mail/demo/send',
+            'GET /mail/demo/queue',
+            'GET /mail/demo/preview',
+            'GET /mail/demo/view',
+        ];
+
+        $byExact = $this->compile([$this->mailDemoPlugin(withSixth: true)], disable: $exact);
+        self::assertArrayHasKey(
+            'GET /mail/demo/blast',
+            $byExact,
+            'exact specs fail OPEN on upgrade — this is the behaviour being fixed',
+        );
+
+        $byPrefix = $this->compile([$this->mailDemoPlugin(withSixth: true)], disable: ['GET /mail/demo/*']);
+        self::assertArrayNotHasKey('GET /mail/demo/blast', $byPrefix, 'a prefix keeps covering what arrives later');
+    }
+
+    public function test_a_prefix_does_not_match_a_sibling_sharing_the_string(): void
+    {
+        // "/mail/demo/*" must not swallow "/mail/demos" — a path-segment
+        // boundary, not a substring.
+        $module = $this->plugin('mail.delivery', [
+            ['method' => 'GET', 'path' => '/mail/demo/send', 'handler' => 'C@a'],
+            ['method' => 'GET', 'path' => '/mail/demos', 'handler' => 'C@b'],
+        ]);
+
+        $manifest = $this->compile([$module], disable: ['GET /mail/demo/*']);
+
+        self::assertArrayNotHasKey('GET /mail/demo/send', $manifest);
+        self::assertArrayHasKey('GET /mail/demos', $manifest);
+    }
+
+    public function test_a_prefix_disable_is_method_specific(): void
+    {
+        // "GET /admin/*" must not silently also drop the POST that mutates —
+        // otherwise a policy meant to hide a page quietly changes write surface.
+        $module = $this->plugin('admin.panel', [
+            ['method' => 'GET', 'path' => '/admin/users', 'handler' => 'C@index'],
+            ['method' => 'POST', 'path' => '/admin/users', 'handler' => 'C@store'],
+        ]);
+
+        $manifest = $this->compile([$module], disable: ['GET /admin/*']);
+
+        self::assertArrayNotHasKey('GET /admin/users', $manifest);
+        self::assertArrayHasKey('POST /admin/users', $manifest);
+    }
+
+    public function test_a_prefix_matching_nothing_still_fails_the_boot(): void
+    {
+        // The anti-typo guard must survive the new form.
+        $this->expectException(BootException::class);
+        $this->expectExceptionMessageMatches('/matched no plugin route/');
+
+        $this->compile([$this->mailDemoPlugin()], disable: ['GET /nope/*']);
+    }
+
+    public function test_the_exact_and_domain_forms_are_unchanged(): void
+    {
+        $manifest = $this->compile([$this->mailDemoPlugin()], disable: ['GET /mail/demo/send']);
+        self::assertArrayNotHasKey('GET /mail/demo/send', $manifest);
+        self::assertArrayHasKey('GET /mail/demo/queue', $manifest);
+
+        $all = $this->compile([$this->mailDemoPlugin()], disable: ['mail.delivery']);
+        self::assertSame([], $all, 'the domain form drops every route the module solves');
+    }
+
+    // ── only: the allowlist ──────────────────────────────────────────────────
+
+    public function test_an_allowlist_drops_everything_it_does_not_name(): void
+    {
+        $manifest = $this->compile(
+            [$this->mailDemoPlugin()],
+            only: ['GET /mail/status'],
+        );
+
+        self::assertSame(['GET /mail/status'], array_keys($manifest));
+    }
+
+    public function test_an_empty_allowlist_means_no_allowlist(): void
+    {
+        // NOT "allow nothing" — that would turn a project which never opted in
+        // into an empty application the moment it upgraded.
+        $manifest = $this->compile([$this->mailDemoPlugin()], only: []);
+
+        self::assertCount(6, $manifest);
+    }
+
+    public function test_an_allowlist_accepts_a_domain_and_a_prefix(): void
+    {
+        $mail  = $this->plugin('mail.delivery', [
+            ['method' => 'GET', 'path' => '/mail/status', 'handler' => 'C@s'],
+        ]);
+        $admin = $this->plugin('admin.panel', [
+            ['method' => 'GET', 'path' => '/admin/a', 'handler' => 'C@a'],
+            ['method' => 'GET', 'path' => '/admin/b', 'handler' => 'C@b'],
+            ['method' => 'GET', 'path' => '/other', 'handler' => 'C@o'],
+        ]);
+
+        $manifest = $this->compile([$mail, $admin], only: ['mail.delivery', 'GET /admin/*']);
+
+        self::assertArrayHasKey('GET /mail/status', $manifest);
+        self::assertArrayHasKey('GET /admin/a', $manifest);
+        self::assertArrayHasKey('GET /admin/b', $manifest);
+        self::assertArrayNotHasKey('GET /other', $manifest);
+    }
+
+    public function test_allow_and_disable_compose(): void
+    {
+        // The intended workflow: allow a module's whole domain, then subtract
+        // the handful of its routes you do not want.
+        $manifest = $this->compile(
+            [$this->mailDemoPlugin()],
+            disable: ['GET /mail/demo/*'],
+            only: ['mail.delivery'],
+        );
+
+        self::assertSame(['GET /mail/status'], array_keys($manifest));
+    }
+
+    public function test_an_allow_spec_matching_nothing_does_not_fail_the_boot(): void
+    {
+        // Unlike a disable spec. An allowlist naming routes from a plugin this
+        // deployment has not enabled is normal for shared/base configuration,
+        // and failing there would make the safer posture the harder one to adopt.
+        $manifest = $this->compile(
+            [$this->mailDemoPlugin()],
+            only: ['GET /mail/status', 'GET /not/installed/yet', 'some.absent.domain'],
+        );
+
+        self::assertSame(['GET /mail/status'], array_keys($manifest));
+    }
+
+    private function deleteTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Unit/Kernel/Events/EventBusScopeTest.php
+++ b/tests/Unit/Kernel/Events/EventBusScopeTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Kernel\Events;
+
+use AlfacodeTeam\PhpServicePlatform\Kernel\Container\CoreContainer;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Container\ModuleContainer;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Events\Contracts\IntegrationEventContract;
+use AlfacodeTeam\PhpServicePlatform\Kernel\Events\EventBus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * An INTERFACE dependency — the shape a real plugin listener has, and the
+ * reason this cannot be papered over by autowiring. A container that has no
+ * binding for it cannot invent one.
+ */
+interface RecorderContract
+{
+    public function record(string $name): void;
+}
+
+final class SpyRecorder implements RecorderContract
+{
+    /** @var list<string> */
+    public array $seen = [];
+
+    public function record(string $name): void
+    {
+        $this->seen[] = $name;
+    }
+}
+
+/** A listener with a constructor dependency a plugin binds in register(). */
+final class DependentListener
+{
+    public function __construct(private readonly RecorderContract $recorder) {}
+
+    public function handle(IntegrationEventContract $event): void
+    {
+        $this->recorder->record($event->name());
+    }
+}
+
+/** A dependency-free listener — the only kind the old `new` fallback could build. */
+final class SimpleListener
+{
+    public static int $calls = 0;
+
+    public function handle(IntegrationEventContract $event): void
+    {
+        self::$calls++;
+    }
+}
+
+final class ScopeTestEvent implements IntegrationEventContract
+{
+    public function name(): string { return 'scope.test'; }
+    public function version(): string { return '1.0'; }
+    public function payload(): array { return []; }
+}
+
+/**
+ * The EventBus is constructed once, at materialize, with the CoreContainer —
+ * while listener dependencies are bound per request, in the ModuleContainer.
+ * That mismatch dropped events silently, and every project papered over it by
+ * hand-assembling listeners into withPorts().
+ */
+#[CoversClass(EventBus::class)]
+final class EventBusScopeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        SimpleListener::$calls = 0;
+    }
+
+    public function test_a_listener_with_an_unbound_dependency_is_still_dropped_quietly(): void
+    {
+        // Characterises the failure mode itself: nothing is bound anywhere, so
+        // the listener genuinely cannot be built. dispatch() must isolate that
+        // — the caller of an integration event must never see it throw.
+        $bus = new EventBus(new CoreContainer());
+        $bus->subscribe('scope.test', DependentListener::class);
+
+        $bus->dispatch(new ScopeTestEvent());
+
+        $this->addToAssertionCount(1); // no throw escaped
+    }
+
+    public function test_forContainer_resolves_a_listener_from_the_request_container(): void
+    {
+        // The fix. RecorderContract is bound exactly where a plugin binds it:
+        // in the request-scoped container, from Provider::register().
+        $core     = new CoreContainer();
+        $recorder = new SpyRecorder();
+
+        $module = new ModuleContainer($core);
+        $module->setScope('');
+        $module->singleton(RecorderContract::class, static fn (): RecorderContract => $recorder);
+
+        $bus = new EventBus($core);
+        $bus->subscribe('scope.test', DependentListener::class);
+
+        $bus->forContainer($module)->dispatch(new ScopeTestEvent());
+
+        self::assertSame(['scope.test'], $recorder->seen);
+    }
+
+    public function test_a_core_bound_listener_still_resolves_through_the_view(): void
+    {
+        // Resolution must be a SUPERSET: the hand-wired withPorts() listeners
+        // every existing project relies on cannot stop working.
+        $recorder = new SpyRecorder();
+
+        $core = new CoreContainer();
+        $core->singleton(
+            DependentListener::class,
+            static fn (): DependentListener => new DependentListener($recorder),
+        );
+
+        $bus = new EventBus($core);
+        $bus->subscribe('scope.test', DependentListener::class);
+
+        $module = new ModuleContainer($core);
+        $module->setScope('');
+
+        $bus->forContainer($module)->dispatch(new ScopeTestEvent());
+
+        self::assertSame(['scope.test'], $recorder->seen);
+    }
+
+    public function test_a_dependency_free_listener_still_runs_with_nothing_bound(): void
+    {
+        // The case the old `new $listenerClass()` fallback existed for. It has
+        // to keep working with no binding and no autowiring help at all.
+        $bus = new EventBus(new CoreContainer());
+        $bus->subscribe('scope.test', SimpleListener::class);
+
+        $bus->dispatch(new ScopeTestEvent());
+
+        self::assertSame(1, SimpleListener::$calls);
+    }
+
+    public function test_making_a_view_does_not_disturb_the_bus_it_came_from(): void
+    {
+        $core = new CoreContainer();
+        $bus  = new EventBus($core);
+        $bus->subscribe('scope.test', SimpleListener::class);
+
+        $module = new ModuleContainer($core);
+        $module->setScope('');
+
+        $bus->forContainer($module)->dispatch(new ScopeTestEvent());
+        self::assertSame(1, SimpleListener::$calls, 'the view carries the subscriptions');
+
+        $bus->dispatch(new ScopeTestEvent());
+        self::assertSame(2, SimpleListener::$calls, 'the original bus still dispatches');
+    }
+}

--- a/tests/Unit/Project/Bootstrap/EnvProjectConfinementTest.php
+++ b/tests/Unit/Project/Bootstrap/EnvProjectConfinementTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Project\Bootstrap;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Project\Bootstrap\Domain\DomainContext;
+use Project\Bootstrap\Domain\DomainType;
+use Project\Bootstrap\Environment\LoadEnvironment;
+
+/**
+ * Tier 3 of the .env cascade is confined to the application root.
+ *
+ * DomainResolver matches the request's Host header against the MACHINE-GLOBAL
+ * projects registry, which lists every project on the host by absolute path. A
+ * Host owned by another project therefore resolves to THAT project's directory,
+ * and tier 3 would read its .env — splicing a foreign APP_KEY, DB_* and
+ * SESSION_* over ours, chosen by a header the caller controls.
+ */
+#[CoversClass(LoadEnvironment::class)]
+final class EnvProjectConfinementTest extends TestCase
+{
+    private string $tmp;
+
+    /** @var array<string, string> */
+    private array $savedEnv = [];
+
+    protected function setUp(): void
+    {
+        $this->tmp = sys_get_temp_dir() . '/hkm-envconfine-' . bin2hex(random_bytes(6));
+        mkdir($this->tmp, 0775, true);
+
+        foreach (['APP_KEY', 'DB_NAME', 'MARKER'] as $key) {
+            if (isset($_ENV[$key])) {
+                $this->savedEnv[$key] = (string) $_ENV[$key];
+            }
+            unset($_ENV[$key], $_SERVER[$key]);
+        }
+
+        LoadEnvironment::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['APP_KEY', 'DB_NAME', 'MARKER'] as $key) {
+            unset($_ENV[$key], $_SERVER[$key]);
+        }
+        foreach ($this->savedEnv as $key => $value) {
+            $_ENV[$key] = $value;
+        }
+
+        LoadEnvironment::reset();
+        $this->deleteTree($this->tmp);
+    }
+
+    public function test_a_foreign_projects_env_is_not_loaded(): void
+    {
+        // Refusing must be LOUD: a misconfigured registry is an operational
+        // problem, and silence looks exactly like "the override did nothing".
+        // Declaring the output here asserts the warning and keeps the suite's
+        // beStrictAboutOutputDuringTests contract intact.
+        $this->expectOutputRegex('/theirs\.local.*was NOT loaded/s');
+
+        // Our application.
+        $root = $this->tmp . '/ours';
+        mkdir($root, 0775, true);
+        file_put_contents($root . '/.env', "APP_KEY=ours\nMARKER=ours\n");
+
+        // A completely separate application on the same machine, which the
+        // global registry happens to map the attacker-supplied Host to.
+        $foreign = $this->tmp . '/theirs';
+        mkdir($foreign, 0775, true);
+        file_put_contents($foreign . '/.env', "APP_KEY=THEIRS\nDB_NAME=their_db\n");
+
+        LoadEnvironment::load($root, new DomainContext(
+            name:        'theirs',
+            projectPath: $foreign,
+            type:        DomainType::Project,
+            host:        'theirs.local',
+        ));
+
+        self::assertSame('ours', $_ENV['APP_KEY'] ?? null, 'a foreign APP_KEY must never win');
+        self::assertSame('ours', $_ENV['MARKER'] ?? null);
+        self::assertArrayNotHasKey('DB_NAME', $_ENV, 'no foreign key may leak in at all');
+    }
+
+    public function test_a_nested_project_under_the_root_still_loads(): void
+    {
+        // The non-flat layout, where tier 3 is exactly the point: the project
+        // lives at <root>/projects/<name> and its .env must still be read.
+        $root = $this->tmp . '/workspace';
+        mkdir($root . '/projects/admin', 0775, true);
+        file_put_contents($root . '/.env', "APP_KEY=base\nMARKER=base\n");
+        file_put_contents($root . '/projects/admin/.env', "MARKER=admin\n");
+
+        LoadEnvironment::load($root, new DomainContext(
+            name:        'admin',
+            projectPath: $root . '/projects/admin',
+            type:        DomainType::Admin,
+            host:        'admin.local',
+        ));
+
+        self::assertSame('base', $_ENV['APP_KEY'] ?? null);
+        // No expectOutputRegex here on purpose: beStrictAboutOutputDuringTests
+        // turns any warning into a failure, so this asserts the legitimate
+        // nested layout is NOT warned about.
+        self::assertSame('admin', $_ENV['MARKER'] ?? null, 'the nested project override must apply');
+    }
+
+    public function test_a_sibling_sharing_a_name_prefix_is_outside(): void
+    {
+        $this->expectOutputRegex('/was NOT loaded/');
+
+        // /srv/app-backup must not count as inside /srv/app. Without the
+        // separator on the prefix test, a plain str_starts_with says it does.
+        $root = $this->tmp . '/app';
+        mkdir($root, 0775, true);
+        file_put_contents($root . '/.env', "MARKER=app\n");
+
+        $sibling = $this->tmp . '/app-backup';
+        mkdir($sibling, 0775, true);
+        file_put_contents($sibling . '/.env', "MARKER=backup\n");
+
+        LoadEnvironment::load($root, new DomainContext(
+            name:        'backup',
+            projectPath: $sibling,
+            type:        DomainType::Project,
+            host:        'backup.local',
+        ));
+
+        self::assertSame('app', $_ENV['MARKER'] ?? null);
+    }
+
+    public function test_the_flat_layout_loads_its_own_project_env_once(): void
+    {
+        // Flat: root IS the project. Tier 1 and tier 3 name the same file; the
+        // guard must not turn that into a refusal.
+        $root = $this->tmp . '/flat';
+        mkdir($root, 0775, true);
+        file_put_contents($root . '/.env', "MARKER=flat\n");
+
+        LoadEnvironment::load($root, new DomainContext(
+            name:        'flat',
+            projectPath: $root,
+            type:        DomainType::Project,
+            host:        'flat.local',
+        ));
+
+        // Likewise: the flat layout is the normal case, and any output here
+        // would fail this test under beStrictAboutOutputDuringTests.
+        self::assertSame('flat', $_ENV['MARKER'] ?? null);
+    }
+
+    private function deleteTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tools/docs/hkm-cli-usage.md
+++ b/tools/docs/hkm-cli-usage.md
@@ -381,8 +381,9 @@ silently falls back to the stable kernel.
   project `/plugins`.
 - **Kernel autoload:** `PSP_GLOBAL_AUTOLOAD` → `HKM_GLOBAL_AUTOLOAD` →
   `HKM_KERNEL_HOME/vendor` → registry-inferred kernel root.
-- **Templates:** `HKM_TEMPLATES_DIR` → `HKM_KERNEL_HOME/tools/src/templates` →
-  next to the binary → FHS `share/hkm/templates` → registry-inferred kernel root.
+- **Templates:** `HKM_TEMPLATES_DIR` → `HKM_KERNEL_HOME/templates` →
+  `<exe_dir>/templates` → FHS `<exe_dir>/../share/hkm/templates` →
+  registry-inferred `<kernel_root>/templates`.
 
 ---
 

--- a/tools/src/commands/plugins.zig
+++ b/tools/src/commands/plugins.zig
@@ -1018,6 +1018,28 @@ fn enableOne(
 
     if (meta) |m| {
         if (m.solves) |s| prompt.muted(try std.fmt.allocPrint(allocator, "    solves: {s}", .{s}));
+        // Enabling a plugin activates EVERY route it declares, at once. Saying
+        // so is the difference between a project that chose its HTTP surface
+        // and one that inherited it: you cannot review, or veto, what you were
+        // never shown.
+        if (m.route_count > 0) {
+            prompt.muted(try std.fmt.allocPrint(
+                allocator,
+                "    publishes {d} HTTP route(s) — audit with `hkm route:list --plugin`",
+                .{m.route_count},
+            ));
+            // Not an error. A login form, robots.txt, or a page shell whose data
+            // sits behind a filtered endpoint are all legitimately unfiltered —
+            // this is the subset that has to be justified one by one.
+            if (m.unfiltered_routes > 0) {
+                prompt.note(try std.fmt.allocPrint(
+                    allocator,
+                    "{d} of them run NO route filter — review with `hkm route:list --unfiltered --plugin`, " ++
+                        "and veto what you will not expose via proj.json routePolicy.",
+                    .{m.unfiltered_routes},
+                ));
+            }
+        }
         if (m.doc != null or m.description != null) prompt.muted("    documentation comment added above the entry");
     }
     if (support_expr) |expr|

--- a/tools/src/lib/plugin_sources.zig
+++ b/tools/src/lib/plugin_sources.zig
@@ -218,6 +218,20 @@ pub const ModuleMeta = struct {
     /// solves. A plugin whose routes require http.pageflow needs Pageflow
     /// installed and enabled exactly as much as one that requires it up top.
     route_requires: []const Requirement = &.{},
+    /// How many HTTP routes this plugin publishes, and how many of those run
+    /// NO filter at all — counted across top-level `routes[]` and every nested
+    /// group, exactly as the route compiler expands them.
+    ///
+    /// Enabling a plugin activates every one of its routes at once, and until
+    /// now the CLI reported none of them: a single install could publish thirty
+    /// endpoints a project never reviewed. You cannot veto what you were never
+    /// shown, so `enable` shows it.
+    ///
+    /// An unfiltered route is not automatically unsafe — a login form, a
+    /// robots.txt, or a page shell whose data sits behind a filtered endpoint
+    /// are all legitimately unfiltered. It is the set that has to be justified.
+    route_count: usize = 0,
+    unfiltered_routes: usize = 0,
     /// "documentation" — preferred enable-time doc (string, or array joined).
     doc: ?[]const u8 = null,
     /// "description" — fallback doc text.
@@ -256,6 +270,8 @@ pub fn readModuleMeta(allocator: std.mem.Allocator, io: Io, pluginsDir: []const 
         .version = strField(parsed.object, "version"),
         .requires = try requiresField(allocator, parsed.object),
         .route_requires = try routeRequiresField(allocator, parsed.object),
+        .route_count = routeStats(parsed.object).total,
+        .unfiltered_routes = routeStats(parsed.object).unfiltered,
         .doc = try docField(allocator, parsed.object, "documentation"),
         .description = strField(parsed.object, "description"),
         .kernel = strField(parsed.object, "kernel"),
@@ -304,6 +320,55 @@ fn routeRequiresField(allocator: std.mem.Allocator, obj: std.json.ObjectMap) ![]
 /// Matches CompileRouteManifestStage::MAX_GROUP_DEPTH — a self-referencing
 /// structure is rejected there, and must not spin here either.
 const max_group_depth: u8 = 16;
+
+pub const RouteStats = struct { total: usize = 0, unfiltered: usize = 0 };
+
+/// Count the routes a module.json publishes, and how many run no filter.
+///
+/// Mirrors the compiler's expansion: a module-wide `routeFilters` and each
+/// group's `filters` are inherited by everything inside them, so a route counts
+/// as filtered when ANY level put something in front of it.
+pub fn routeStats(obj: std.json.ObjectMap) RouteStats {
+    var stats: RouteStats = .{};
+    countRoutes(obj, false, &stats, 0);
+    return stats;
+}
+
+fn countRoutes(obj: std.json.ObjectMap, inherited: bool, stats: *RouteStats, depth: u8) void {
+    if (depth > max_group_depth) return;
+
+    var guarded = inherited;
+    if (nonEmptyArray(obj, "routeFilters")) guarded = true;
+    // "filters" is a GROUP key; at the top level the module-wide spelling is
+    // "routeFilters", and reading both there would misread an unrelated key.
+    if (depth > 0 and nonEmptyArray(obj, "filters")) guarded = true;
+
+    if (obj.get("routes")) |routes| {
+        if (routes == .array) {
+            for (routes.array.items) |route| {
+                if (route != .object) continue;
+                stats.total += 1;
+                if (!(guarded or nonEmptyArray(route.object, "filters"))) {
+                    stats.unfiltered += 1;
+                }
+            }
+        }
+    }
+
+    if (obj.get("groups")) |groups| {
+        if (groups == .array) {
+            for (groups.array.items) |group| {
+                if (group != .object) continue;
+                countRoutes(group.object, guarded, stats, depth + 1);
+            }
+        }
+    }
+}
+
+fn nonEmptyArray(obj: std.json.ObjectMap, key: []const u8) bool {
+    const v = obj.get(key) orelse return false;
+    return v == .array and v.array.items.len > 0;
+}
 
 /// Walk one route-declaration source: its module-wide `routeRequires`, each
 /// `routes[].requires[]`, and every nested group, recursively.
@@ -518,4 +583,66 @@ test "a self-referencing group structure terminates" {
 
     const got = try testRouteRequires(arena.allocator(), buf.items);
     _ = got; // reaching here at all is the assertion: it returned.
+}
+
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+/// Parse into an arena: parseFromSliceLeaky never frees, which the testing
+/// allocator correctly reports as a leak. The arena owns everything and is
+/// released when the test returns.
+fn statsFor(src: []const u8) !RouteStats {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const parsed = try std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), src, .{});
+    return routeStats(parsed.object);
+}
+
+test "counts top-level routes and spots the unfiltered ones" {
+    const s = try statsFor(
+        \\{"routes":[
+        \\ {"method":"GET","path":"/a"},
+        \\ {"method":"GET","path":"/b","filters":["auth"]}
+        \\]}
+    );
+    try std.testing.expectEqual(@as(usize, 2), s.total);
+    try std.testing.expectEqual(@as(usize, 1), s.unfiltered);
+}
+
+test "a module-wide routeFilters guards every route" {
+    const s = try statsFor(
+        \\{"routeFilters":["auth"],"routes":[
+        \\ {"method":"GET","path":"/a"},
+        \\ {"method":"GET","path":"/b"}
+        \\]}
+    );
+    try std.testing.expectEqual(@as(usize, 2), s.total);
+    try std.testing.expectEqual(@as(usize, 0), s.unfiltered);
+}
+
+test "group filters are inherited by nested groups" {
+    const s = try statsFor(
+        \\{"groups":[
+        \\ {"filters":["auth"],"routes":[{"method":"GET","path":"/x"}],
+        \\  "groups":[{"routes":[{"method":"GET","path":"/y"}]}]},
+        \\ {"routes":[{"method":"GET","path":"/z"}]}
+        \\]}
+    );
+    try std.testing.expectEqual(@as(usize, 3), s.total);
+    // /x and /y inherit auth; only /z is bare.
+    try std.testing.expectEqual(@as(usize, 1), s.unfiltered);
+}
+
+test "an empty filters array does not count as guarded" {
+    const s = try statsFor(
+        \\{"routes":[{"method":"GET","path":"/a","filters":[]}]}
+    );
+    try std.testing.expectEqual(@as(usize, 1), s.unfiltered);
+}
+
+test "a manifest with no routes counts nothing" {
+    const s = try statsFor("{\"solves\":\"x.y\"}");
+    try std.testing.expectEqual(@as(usize, 0), s.total);
+    try std.testing.expectEqual(@as(usize, 0), s.unfiltered);
 }


### PR DESCRIPTION
Merging this pushes `v1.7.0` (auto-release reads the first versioned CHANGELOG heading, then builds and updates the Homebrew formula). Verified free: no `v1.7.0` tag exists.

## Security

**A `Host:` header could make one project load another project's `.env`.** `DomainResolver` matches the request host against the machine-global registry (`HKM_USERDATA_DIR/projects.json`), which lists every project by absolute path — so a host owned by a *different* project resolved to that project's directory, and tier 3 of the cascade read its `.env` with no check that it was the app being served. Result: a foreign `APP_KEY`, `DB_*` and `SESSION_*` spliced over ours, chosen by a header the caller controls; with `ENV_CACHE=1`, the merged result (our secrets included) was then written under *that* project's `var/cache`.

Tier 3 is now confined to the application root. The test is **containment, not equality**, because both layouts are legitimate — flat (project path *is* the root) and nested (`<root>/projects/<name>`). Compared after `realpath()`, with an explicit separator on the prefix test so `/srv/app-backup` is not treated as inside `/srv/app`.

**When the environment loads is unchanged** — still before `Kernel::build()`. Only *which directory* tier 3 will read has changed.

## Added

- **`routePolicy.only`** — an allowlist. `disable` only subtracts, so it helps once you already know a route exists, and one `hkm plugins install` can publish thirty. Empty means "no allowlist" (not "allow nothing" — that would empty an app on upgrade), and an unmatched allow spec does *not* fail the boot, unlike a disable spec.
- **Prefix specs** — `"GET /mail/demo/*"`. The exact form fails **open** on upgrade: five exact keys stay green when a plugin's next release adds a sixth. Method-specific and segment-bounded.
- **`module.json` `"files"`** — plugins are reached through the PSR-4 map, so no plugin's `composer.json` is ever read: fine for classes, fatal for functions. Composer `autoload.files` is honoured as a fallback, so existing plugins need no change. A declared-but-missing file now fails the boot.

## Fixed

- **Plugin event listeners with dependencies were silently dropped.** `EventBus` was built with the `CoreContainer`; listener deps are bound per request into the `ModuleContainer`. Dispatch also gated on `has()`, which reports only explicit bindings — so any listener with constructor args fell through to `new`, threw `ArgumentCountError`, and was logged as a failed listener. Projects hand-wired listeners into `withPorts()` to compensate. Resolution is now a strict **superset** of before.
- **`BOOT_CACHE` could silently skip a manifest a newer kernel added** — sentinel is a list now; the allowlist is in the stamp key so tightening it cannot leave the wider manifest cached.
- **Templates** — duplicate `HashingPort` binding, dead import, a pool warmed on *every* FPM request, `getenv()` that cannot see `.env` in the worker, the domain read from `require` scope in the front controller, unpinned timezone.

## Verification

- **389 tests, 723 assertions** green (was 359/664) · PHPStan clean · `zig build test` clean
- Booted against the real project on the dev kernel: CLI, PHP-FPM and **OpenSwoole**. 300 sequential requests, 0 failures, worker RSS +16 KB (no leak from the per-request EventBus view). 60 concurrent requests across 3 `Host` values, all 200. CSRF still denies an unguarded POST with 403.
- The `BOOT_CACHE` sentinel was verified by *forcing* the upgrade case: with `files-manifest.php` removed and an otherwise-valid stamp, the cache correctly missed and recompiled.
- The `files` fallback was verified against the real Authorization plugin: `stripInlineComments()` goes from undefined to defined.

**Not exercised:** the queue worker entry point. Its `getenv()` → `env()` fix is reasoned, not run.

## Companion change (not in this PR)

`route:list --unfiltered --plugin` lives in `hkm-plugin-commands` and needs its own release.
