### PR TITLE
chore(homebrew): point the formula at v1.7.0

### DIFF
--- a/HomebrewFormula/hkm.rb
+++ b/HomebrewFormula/hkm.rb
@@ -34,8 +34,8 @@
 class Hkm < Formula
   desc "CLI for the HKM kernel, a modular PHP service platform"
   homepage "https://github.com/AlfaCode-Team/hkm-kernel"
-  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.6.1/hkm-kernel-1.6.1-macos-universal.tar.gz"
-  sha256 "3f4de9e3666be8f7333d905cc6d778994308bdf057bef69a92d084ed5a24e767"
+  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.7.0/hkm-kernel-1.7.0-macos-universal.tar.gz"
+  sha256 "af26ceb13130f3350676604e2a0410f2c011ba56c2a3bf4fbf67aab037747403"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
Completes the **v1.7.0** release. The `homebrew` job computed and committed this correctly but could not open its own PR:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

It pushed `homebrew/bump-v1.7.0`, emitted a warning, and filed #130 as a reminder — which is exactly the loud failure #128 added. Opening the PR by hand is the sanctioned last step; **the digest was still computed by the job, not pasted by a human.**

## Verified against the published asset

```
asset  sha256: af26ceb13130f3350676604e2a0410f2c011ba56c2a3bf4fbf67aab037747403
formula sha256: af26ceb13130f3350676604e2a0410f2c011ba56c2a3bf4fbf67aab037747403
MATCH
```

Downloaded from the v1.7.0 release (`hkm-kernel-1.7.0-macos-universal.tar.gz`, 1,311,979 bytes) and hashed locally. Diff is `HomebrewFormula/hkm.rb` only — 2 insertions, 2 deletions.

Until this lands, `brew install hkm` keeps resolving to **v1.6.1**.

## Root cause, so it stops recurring

The org/repo setting **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** is off. The job already prefers a direct push to `main` and falls back to a PR; branch protection blocks the push, and that setting blocks the fallback, so both paths are closed. Enabling it makes this self-healing.

Closes #130
