### PR TITLE
chore(homebrew): point the formula at v1.8.0

### DIFF
--- a/HomebrewFormula/hkm.rb
+++ b/HomebrewFormula/hkm.rb
@@ -34,8 +34,8 @@
 class Hkm < Formula
   desc "CLI for the HKM kernel, a modular PHP service platform"
   homepage "https://github.com/AlfaCode-Team/hkm-kernel"
-  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.7.0/hkm-kernel-1.7.0-macos-universal.tar.gz"
-  sha256 "af26ceb13130f3350676604e2a0410f2c011ba56c2a3bf4fbf67aab037747403"
+  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.8.0/hkm-kernel-1.8.0-macos-universal.tar.gz"
+  sha256 "be82142298243c0a825f8cddd0c7c770b197ff92d38bbd754a2548991a6654a5"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
Follows #132 (v1.8.0). The release published all six assets successfully; only
this last step could not land itself.

`url` and `sha256` come from the release job's own bump commit — the digest is
of the tarball GitHub built from the tag, verified against the published asset:

    be82142298243c0a825f8cddd0c7c770b197ff92d38bbd754a2548991a6654a5

Until this merges, every `brew install hkm` / `brew upgrade hkm` still resolves
to v1.7.0.

Closes #133.

### Why this is manual

The `homebrew` job pushed the branch, then hit:

> `GitHub Actions is not permitted to create or approve pull requests`

That switch is held at the ORGANIZATION level, so no repository setting can
override it, and this will recur on every release until an org admin changes it.
Leaving it off is arguably the better trade — the same setting also lets Actions
*approve* PRs, which on a review-protected branch would let a workflow satisfy
that requirement by itself.
