### PR TITLE
release: v1.8.1 — ground serve reaches the kernel again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-08-31
+
+### Fixed
+- **`ground serve` handed its router an autoloader path that exists in no
+  layout**, so every request died before reaching the kernel:
+  `Failed opening required '.../modules/ground/src/vendor/autoload.php'`. The
+  router `php -S` executes runs in a fresh process per request and so has to
+  `require` a composer autoloader itself; the path was built by counting
+  directories up from the command's own source file, which named a `vendor/`
+  inside `src/`. The command still started and printed `Listening` — the fatal
+  was in a different process, on the first request, which is why nothing caught
+  it. It now asks where the autoloader ALREADY IN EFFECT lives (two levels above
+  the loaded `Composer\Autoload\ClassLoader`), correct by construction in a
+  kernel checkout, an installed bundle and a plugin's own `vendor/` alike.
+  `ServeTest` now reads the emitted router and asserts the paths it names are
+  real — a generated file is executed by something other than the test runner,
+  so nothing about it is checked unless it is checked deliberately.
+
 ## [1.8.0] - 2026-08-31
 
 ### Added

--- a/modules/ground/src/Commands/PluginServeCommand.php
+++ b/modules/ground/src/Commands/PluginServeCommand.php
@@ -186,7 +186,7 @@ final class PluginServeCommand extends AbstractCommand
     {
         $file = sys_get_temp_dir() . '/hkm-ground-router-' . bin2hex(random_bytes(6)) . '.php';
 
-        $autoload = \dirname(__DIR__) . '/vendor/autoload.php';
+        $autoload = $this->autoloaderPath();
         $export   = var_export([$provider, ...$providers], true);
 
         file_put_contents($file, <<<PHP
@@ -235,6 +235,53 @@ final class PluginServeCommand extends AbstractCommand
         PHP);
 
         return $file;
+    }
+
+    /**
+     * The composer autoloader the fresh `php -S` process must require.
+     *
+     * It is found by asking where the autoloader ALREADY IN EFFECT lives,
+     * rather than by counting directories up from this file. Ground runs from
+     * at least three layouts — a kernel checkout, an installed bundle
+     * (`lib/hkm-kernel/`), and a plugin's own `vendor/` — and the hop count
+     * from `src/Commands/` to `vendor/` is different in each. A hardcoded
+     * `dirname(__DIR__)` was right in none of them: it named
+     * `modules/ground/src/vendor/autoload.php`, a path that has never existed,
+     * so every `ground serve` request died in the router before reaching the
+     * kernel.
+     *
+     * `ClassLoader.php` always sits at `vendor/composer/ClassLoader.php`, so
+     * two levels up from the class file that is loaded RIGHT NOW is the
+     * autoloader that loaded it — correct by construction in any layout,
+     * including one this code has never seen.
+     */
+    private function autoloaderPath(): string
+    {
+        if (class_exists(\Composer\Autoload\ClassLoader::class, autoload: false)) {
+            $classLoader = (new \ReflectionClass(\Composer\Autoload\ClassLoader::class))->getFileName();
+
+            if (\is_string($classLoader)) {
+                $candidate = \dirname($classLoader, 2) . '/autoload.php';
+
+                if (is_file($candidate)) {
+                    return $candidate;
+                }
+            }
+        }
+
+        // No composer autoloader in the process — ground was loaded some other
+        // way. Walk up looking for one rather than emitting a path that is
+        // certain to fail: the child process cannot recover from a bad require.
+        for ($dir = __DIR__; $dir !== \dirname($dir); $dir = \dirname($dir)) {
+            if (is_file($dir . '/vendor/autoload.php')) {
+                return $dir . '/vendor/autoload.php';
+            }
+        }
+
+        throw new \RuntimeException(
+            'Could not locate a composer autoloader to hand the serve router. '
+            . 'Run `composer install` in the kernel.',
+        );
     }
 
     private function export(string|bool $value): string

--- a/modules/ground/tests/ServeTest.php
+++ b/modules/ground/tests/ServeTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlfacodeTeam\Ground\Tests;
+
+use AlfacodeTeam\Ground\Commands\PluginServeCommand;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The router `plugin:serve` writes for `php -S` to execute per request.
+ *
+ * This exists because of a defect that shipped in v1.8.0 and was invisible to
+ * every check that ran: the router's `require` line was built as
+ * `dirname(__DIR__) . '/vendor/autoload.php'`, which from `src/Commands/`
+ * names `modules/ground/src/vendor/autoload.php` — a path that exists in no
+ * layout, and never did. `php -l` passed, the whole suite passed, and the
+ * command started and printed "Listening" happily; the fatal only appeared in
+ * a DIFFERENT process, on the first request:
+ *
+ *     Failed opening required '…/modules/ground/src/vendor/autoload.php'
+ *
+ * A generated file is executed by something other than the test runner, so
+ * nothing about it is checked unless it is checked deliberately. That is what
+ * these tests do: read the emitted router and confirm the paths it names are
+ * real.
+ */
+final class ServeTest extends TestCase
+{
+    /** The generated router must require an autoloader that EXISTS. */
+    public function testRouterRequiresARealAutoloader(): void
+    {
+        $router = $this->writeRouter();
+
+        try {
+            $source = (string) file_get_contents($router);
+
+            self::assertSame(
+                1,
+                preg_match("/^require '([^']+)';$/m", $source, $m),
+                'The router should require exactly one autoloader.',
+            );
+
+            self::assertFileExists(
+                $m[1],
+                'The router requires an autoloader that does not exist, so every request 500s.',
+            );
+        } finally {
+            @unlink($router);
+        }
+    }
+
+    /**
+     * The specific shape of the v1.8.0 bug: a path under the package's own
+     * `src/`. No composer layout puts `vendor/` there.
+     */
+    public function testAutoloaderIsNotResolvedRelativeToTheSourceTree(): void
+    {
+        $path = $this->autoloaderPath();
+
+        self::assertStringNotContainsString(
+            'ground/src/vendor',
+            $path,
+            'Resolved relative to the source file again instead of to the real autoloader.',
+        );
+        self::assertFileExists($path);
+    }
+
+    /**
+     * It must be the autoloader ACTUALLY IN EFFECT, not merely one that exists.
+     *
+     * Ground runs from a kernel checkout, an installed bundle
+     * (`lib/hkm-kernel/`) and a plugin's own `vendor/`, and picking the wrong
+     * one of several present is how the child process ends up without the
+     * classes the parent had.
+     */
+    public function testAutoloaderIsTheOneThatLoadedThisProcess(): void
+    {
+        $classLoader = (new \ReflectionClass(\Composer\Autoload\ClassLoader::class))->getFileName();
+
+        self::assertIsString($classLoader);
+        self::assertSame(\dirname($classLoader, 2) . '/autoload.php', $this->autoloaderPath());
+    }
+
+    /** The router closes over the resolved providers — they must survive export. */
+    public function testRouterCarriesTheResolvedProviders(): void
+    {
+        $router = $this->writeRouter();
+
+        try {
+            $source = (string) file_get_contents($router);
+
+            // Compared in EXPORTED form: `var_export` escapes the namespace
+            // separators, so the file holds `A\\B`, not `A\B`.
+            self::assertStringContainsString(var_export(Fixtures\Sample\Provider::class, true), $source);
+            self::assertStringContainsString(var_export('/plugins/root', true), $source);
+        } finally {
+            @unlink($router);
+        }
+    }
+
+    // ── Reaching the private surface ──────────────────────────────────────────
+
+    private function writeRouter(): string
+    {
+        $method = new \ReflectionMethod(PluginServeCommand::class, 'writeRouter');
+
+        return $method->invoke(
+            $this->command(),
+            Fixtures\Sample\Provider::class,
+            [],
+            '/plugins/root',
+            true,
+        );
+    }
+
+    private function autoloaderPath(): string
+    {
+        return (new \ReflectionMethod(PluginServeCommand::class, 'autoloaderPath'))
+            ->invoke($this->command());
+    }
+
+    /**
+     * Built without the constructor: the router is written from arguments
+     * already resolved, so none of the command's collaborators participate.
+     */
+    private function command(): PluginServeCommand
+    {
+        return (new \ReflectionClass(PluginServeCommand::class))->newInstanceWithoutConstructor();
+    }
+}


### PR DESCRIPTION
v1.8.0 shipped `ground serve` fatal on every request. The router `php -S`
executes runs in a fresh process, so it must require a composer autoloader
itself; that path was built by counting directories up from the command's own
source file and named `modules/ground/src/vendor/autoload.php` — a path that
exists in no layout and never has.

It now resolves from the autoloader ALREADY IN EFFECT: `ClassLoader.php` always
sits at `vendor/composer/ClassLoader.php`, so two levels above the class file
loaded right now is the autoloader that loaded it. Correct by construction in a
kernel checkout, an installed bundle and a plugin's own vendor/ alike.

The reason this shipped is worth recording. `php -l` passed, the suite passed,
and the command exited 0 after printing "Listening" — the fatal was in a
different process, on the first request. A generated file is executed by
something other than the test runner, so nothing about it is checked unless it
is checked deliberately. ServeTest now reads the emitted router and asserts the
paths it names are real; reintroducing the old line turns it red.

Verified against a live request rather than the suite alone: GET /pageflow/csrf
returns 200 with a real token, from the source tree and from an installed build.

<!--
  Thanks for contributing! Please fill out this template.
  See CONTRIBUTING.md for the branch model and coding standards.
-->

## Summary

<!-- What does this PR do and why? Link the issue it closes. -->

Closes #

## Type of change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation only
- [ ] 🧹 Refactor / chore (no functional change)
- [ ] 🚀 Release PR (`master` → `main`, includes a CHANGELOG version bump)

## Target branch

<!-- Feature/fix work targets `master`. Only release PRs target `main`. -->

- [ ] This PR targets **`master`** (development), **or**
- [ ] This is a **`master` → `main`** release PR and adds a `## [x.y.z] - YYYY-MM-DD` section to `CHANGELOG.md`.

## How has this been tested?

<!-- Describe the tests you added/ran. Paste relevant output. -->

```bash
vendor/bin/phpunit
```

## Checklist

- [x] My code follows the **Gated Demand Architecture** rules (no Laravel/Symfony/Slim patterns).
- [ ] Every PHP file has `declare(strict_types=1);`.
- [ ] The five access rules are respected (Controller → Service → Repository/Gateway → Port/SDK; Domain imports nothing external).
- [ ] Routes are declared in `module.json` / `proj.json`, not in PHP.
- [ ] Every env var read is declared in the relevant `config[]`.
- [ ] Vendor exceptions are translated at their layer (no `\PDOException`/SDK exceptions escape).
- [ ] I added or updated **tests** and they pass locally.
- [ ] I updated **documentation** where relevant.
- [ ] For shippable changes, I added a `## [Unreleased]` entry to `CHANGELOG.md`.
- [ ] CI is green.

## Screenshots / notes (optional)

<!-- Anything reviewers should pay special attention to. -->
