### PR TITLE
chore(homebrew): point the formula at v1.8.1

### DIFF
--- a/HomebrewFormula/hkm.rb
+++ b/HomebrewFormula/hkm.rb
@@ -34,8 +34,8 @@
 class Hkm < Formula
   desc "CLI for the HKM kernel, a modular PHP service platform"
   homepage "https://github.com/AlfaCode-Team/hkm-kernel"
-  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.8.0/hkm-kernel-1.8.0-macos-universal.tar.gz"
-  sha256 "be82142298243c0a825f8cddd0c7c770b197ff92d38bbd754a2548991a6654a5"
+  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.8.1/hkm-kernel-1.8.1-macos-universal.tar.gz"
+  sha256 "f8e13754aadee8607afbfa2689a44decb93ba2d20152c2b2f027ea898eaafb18"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
Follows #135 (v1.8.1). The release published every asset successfully; only this
last step could not land itself.

`url` and `sha256` come from the release job's own bump commit. The digest is of
the tarball GitHub built from the tag, verified against the published asset:

    f8e13754aadee8607afbfa2689a44decb93ba2d20152c2b2f027ea898eaafb18

Until this merges, `brew install hkm` / `brew upgrade hkm` still resolves v1.8.0
— which ships `ground serve` fatal on every request, the bug v1.8.1 exists to
fix.

Closes #136.

### Why this is manual, again

The `homebrew` job could not push to `main` (branch protection), then could not
open the PR either:

> `GitHub Actions is not permitted to create or approve pull requests`

That switch is held at the ORGANIZATION level, so no repository setting
overrides it, and this recurs on every release — #134 was the same. Worth noting
the same setting also lets Actions *approve* pull requests, which on a
review-protected branch would let a workflow satisfy that requirement itself.
Opening one PR by hand per release is the more conservative trade.
