### PR TITLE
chore(homebrew): point the formula at v1.9.0

### DIFF
--- a/HomebrewFormula/hkm.rb
+++ b/HomebrewFormula/hkm.rb
@@ -34,8 +34,8 @@
 class Hkm < Formula
   desc "CLI for the HKM kernel, a modular PHP service platform"
   homepage "https://github.com/AlfaCode-Team/hkm-kernel"
-  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.8.1/hkm-kernel-1.8.1-macos-universal.tar.gz"
-  sha256 "f8e13754aadee8607afbfa2689a44decb93ba2d20152c2b2f027ea898eaafb18"
+  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.9.0/hkm-kernel-1.9.0-macos-universal.tar.gz"
+  sha256 "922c858200b8f3f3aa380f9a1195aee7af14092d1ff54f1d16587972ad8c9e05"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
Repoints `HomebrewFormula/hkm.rb` at the v1.9.0 macOS universal tarball.

```
url    …/releases/download/v1.8.1/hkm-kernel-1.8.1-macos-universal.tar.gz
    →  …/releases/download/v1.9.0/hkm-kernel-1.9.0-macos-universal.tar.gz
sha256 f8e13754aadee8607afbfa2689a44decb93ba2d20152c2b2f027ea898eaafb18
    →  922c858200b8f3f3aa380f9a1195aee7af14092d1ff54f1d16587972ad8c9e05
```

The digest is verified against the published asset itself — the GitHub API
reports `digest: sha256:922c8582…` for `hkm-kernel-1.9.0-macos-universal.tar.gz`
(1,441,337 bytes), which is the value the formula now carries. Nothing here was
edited by hand; the `homebrew` job computed it from the tarball GitHub built
from the tag.

### Why this PR is manual, again

The `homebrew` job could not push to `main` (branch protection), then could not
open the PR either — Actions is not permitted to create pull requests, and that
switch is held at the ORGANIZATION level, so no repository setting overrides it.
Same as #134 and #136. Its annotation says as much:

> Homebrew formula NOT bumped — finish it at `compare/main...homebrew/bump-v1.9.0`
