### PR TITLE
release: v1.10.0 — ground dev bench, hot-file fixes, theme provider + sidebar tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-09-01
+
+### Added
+- **`ground dev` renders a plugin's pages on a BENCH rather than bare.** The
+  generated entry handed Pageflow's `<App>` no `children`, so a page that
+  declares no `.layout` — three of the eight plugin admin pages on disk — opened
+  as unstyled markup on a white document, which reads like the page is broken
+  rather than like a one-line assignment has not been written yet.
+
+  The entry now frames every page in `GroundFrame` (`@ground/dev`, new, in this
+  package's own `ui/`). It is a FRAME, not a replacement layout: the production
+  tree renders untouched inside it, because `ground serve` running the real
+  pipeline is the only reason to trust what it shows. The layout therefore
+  becomes a control rather than a decision — `page` (the page's own `.layout`,
+  else the admin shell for an `admin/Pages` page and nothing for a `site/Pages`
+  one), `bare`, `admin`, `auth`.
+
+  The bench also carries what only ground knows: every page from the glob with
+  the route that renders it (a page no route reaches was previously unreachable
+  in a browser at all), the plugin's routes with prefixes and filters resolved,
+  the Pageflow page object, and an `adminShell` seeder.
+
+- **`PluginManifest::expandedRoutes()`** — every route with its module and group
+  prefixes, names, filters and `requires` resolved. `allRoutes()` deliberately
+  leaves entries as written, which is right for checking declarations and wrong
+  for anything that navigates: a route declared `/{id}` inside `{"prefix":
+  "/admin"}` under `"routePrefix": "/api"` is served at `/api/admin/{id}`.
+
+- **The `--sidebar-*` design tokens**, in the shared frontend theme. The admin
+  shell in `@pageflow/admin` names eleven of them (`bg-sidebar-bg`,
+  `text-sidebar-fg-muted`, `w-[var(--sidebar-width)]`, …) and not one was defined
+  anywhere — the shell was ported out of HKM 0.3 and its stylesheet was left
+  behind, so the sidebar rendered transparent with no width in every project. An
+  undefined custom property is not an error, so nothing reported it.
+
+### Fixed
+- **`ground dev` marked only ONE surface hot, so pages on any other surface got
+  no scripts at all.** PHP looks for `{surface}-hot` for whichever surface the
+  CONTROLLER named; `--mode` wrote one file. A plugin whose pages render on
+  `site` therefore served a bare shell with an empty `#app` while `yarn dev` sat
+  there reporting itself ready on `admin` — no error in the PHP log, nothing in
+  the console. One server serves every entry under the same root, so every
+  declared surface is now marked hot.
+
+- **A dev server that failed to start deleted a running one's hot file.** The
+  cleanup was armed in `configureServer`, which runs before the port is bound,
+  so with `strictPort` a second `yarn dev` exited during startup and removed the
+  hot file belonging to the server that was working. Ownership is now claimed
+  inside the `listening` handler, and the teardown hooks are armed there too.
+
+- **`ground dev` loaded no CSS at all.** The generated config had no Tailwind
+  plugin and the entry imported no stylesheet, while the pages, the shared `@ui`
+  kit and the admin shell are all Tailwind-only. Every page rendered unstyled.
+  The workspace now generates a stylesheet — the kernel theme inlined, so
+  `@import "tailwindcss"` resolves from a location that has it — with explicit
+  `@source` directives, since Tailwind's automatic scan stops at gitignored
+  directories and every file that matters is outside it.
+
+- **The scaffolded vitest tests never applied a page's `.layout`.** They rendered
+  a bare `<Page />`, so the shell around it — the thing most likely to break —
+  was never exercised. They now apply `Page.layout ?? AdminLayout`, which
+  immediately surfaced that jsdom implements neither `matchMedia` nor
+  `ResizeObserver`, both reached by `AdminLayout` on its first render; the
+  generated `setup.ts` now supplies both. `@testing-library/dom` was also missing
+  from the generated `package.json` — a peer of `@testing-library/react` since
+  v16, without which the whole suite dies on import.
+
+- **The shared `ThemeProvider` did not implement the API its own consumers
+  call.** It exposed `{ theme, toggle }` with `theme: "light" | "dark"`, while
+  `@pageflow/admin`'s `ThemeToggle` destructures `setTheme` and calls it with
+  `"light" | "dark" | "system"` — so every click on the theme switch called
+  `undefined` — and the shared `sonner.tsx` does `const { theme = 'system' }`.
+  Neither failure is visible to a type-check or a build. The provider now
+  exposes `setTheme` and `resolvedTheme`, treats `system` as a real third state
+  that keeps tracking the OS, and guards `localStorage` in both directions (the
+  unguarded read in the state initializer took the whole app down before first
+  paint in a private window).
+
+### Changed
+- The default theme is now `system` rather than `light`. Anyone who has never
+  chosen one follows their OS — which is what `sonner.tsx` already assumed.
+
 ## [1.9.0] - 2026-08-31
 
 ### Added

--- a/modules/ground/.gitignore
+++ b/modules/ground/.gitignore
@@ -4,3 +4,5 @@ composer.lock
 .phpunit.result.cache
 composer.local.json
 composer.local.lock
+
+__dev__

--- a/modules/ground/src/Commands/MakeUiTestCommand.php
+++ b/modules/ground/src/Commands/MakeUiTestCommand.php
@@ -107,10 +107,12 @@ final class MakeUiTestCommand extends AbstractCommand
 
         file_put_contents($file, <<<TSX
             import { describe, it, expect } from "vitest";
+            import { createElement } from "react";
             // Add `screen` here when you assert on what the user sees:
             //   import { render, screen } from "@testing-library/react";
             import { render } from "@testing-library/react";
             import { PageContext } from "@pageflow/react";
+            import { AdminLayout } from "@pageflow/admin";
             import Page from "{$import}";
             import fixture from "../__fixtures__/{$slug}.json";
 
@@ -134,12 +136,25 @@ final class MakeUiTestCommand extends AbstractCommand
              * as JSX attributes renders nothing. The value is the whole page object —
              * the same thing <App> supplies at runtime, and the same shape the fixture
              * holds.
+             *
+             * The LAYOUT is applied for the same reason. Rendering a bare <Page />
+             * tested the page body and nothing around it: a page whose `.layout`
+             * throws, or whose shell needs a prop the server stopped sending, passed
+             * here and broke in the browser. This mirrors what <App> does — honour
+             * `Component.layout` when there is one, fall back to <AdminLayout> when
+             * there is not — so the test renders the same tree a request does.
              */
             function renderPage() {
+              const child = createElement(Page as any, fixture.props as any);
+              const layout = (Page as any).layout;
+
+              const tree =
+                typeof layout === "function"
+                  ? layout(child)
+                  : <AdminLayout>{child}</AdminLayout>;
+
               return render(
-                <PageContext.Provider value={fixture as any}>
-                  <Page />
-                </PageContext.Provider>,
+                <PageContext.Provider value={fixture as any}>{tree}</PageContext.Provider>,
               );
             }
 
@@ -322,6 +337,57 @@ final class MakeUiTestCommand extends AbstractCommand
                 },
               });
             }
+
+            // jsdom implements no matchMedia AT ALL — it is not a stub that
+            // returns false, the property is simply absent. Every page rendered
+            // in the admin shell hits it on the first render (AdminLayout →
+            // useIsMobile → useMediaQuery), so without this the layout throws
+            // "window.matchMedia is not a function" and the failure names the
+            // shell rather than the page under test.
+            //
+            // It answers "not matching", i.e. the DESKTOP branch, because that
+            // is the layout a test asserting on a sidebar expects. Override it
+            // in a single test to render the mobile drawer instead.
+            if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+              Object.defineProperty(window, "matchMedia", {
+                configurable: true,
+                writable: true,
+                value: (query: string): MediaQueryList =>
+                  ({
+                    matches: false,
+                    media: query,
+                    onchange: null,
+                    addEventListener: () => {},
+                    removeEventListener: () => {},
+                    dispatchEvent: () => false,
+                    // Deprecated, but still what some libraries reach for first.
+                    addListener: () => {},
+                    removeListener: () => {},
+                  }) as unknown as MediaQueryList,
+              });
+            }
+
+            // Also absent from jsdom, and reached on MOUNT rather than on
+            // render: the shell's SidebarNav observes its own container to
+            // decide how many nav items fit. A constructor that does not exist
+            // throws from inside a passive effect, so the stack names React's
+            // commit phase and not the component — which is a long way from
+            // "jsdom has no ResizeObserver".
+            //
+            // The stub never fires. A test that needs the overflow branch has
+            // to drive it explicitly; one that does not gets a stable layout
+            // instead of a resize it did not ask for.
+            if (typeof globalThis.ResizeObserver === "undefined") {
+              Object.defineProperty(globalThis, "ResizeObserver", {
+                configurable: true,
+                writable: true,
+                value: class {
+                  observe() {}
+                  unobserve() {}
+                  disconnect() {}
+                },
+              });
+            }
             TS) ? 1 : 0;
 
         if ($written > 0) {
@@ -344,6 +410,13 @@ final class MakeUiTestCommand extends AbstractCommand
      * wired declare in their own ui.json — rendering an admin page without
      * `lucide-react` fails on the first icon, and guessing that list is how it
      * goes stale.
+     *
+     * Tailwind is in devDependencies for the DEV SERVER, not for vitest: the
+     * config `ground dev` generates loads `@tailwindcss/vite`, and the
+     * stylesheet it writes opens with `@import "tailwindcss"`, resolved from
+     * this ui/'s node_modules. Both are missing without these three, and the
+     * failure lands on whoever runs `yarn dev` rather than on whoever ran
+     * `ground install`.
      */
     private function packageJson(UiWorkspace $workspace): string
     {
@@ -357,6 +430,12 @@ final class MakeUiTestCommand extends AbstractCommand
             ],
             'dependencies'    => $workspace->dependencies === [] ? new \stdClass() : $workspace->dependencies,
             'devDependencies' => [
+                '@tailwindcss/vite'         => '^4.0.0',
+                // A PEER of @testing-library/react since v16, so npm does not
+                // pull it in and jest-dom's matchers fail to import — the whole
+                // suite dies before a test runs, naming a package nobody asked
+                // for.
+                '@testing-library/dom'      => '^10.4.0',
                 '@testing-library/jest-dom' => '^6.6.0',
                 '@testing-library/react'    => '^16.1.0',
                 '@types/react'              => '^19.0.0',
@@ -365,6 +444,8 @@ final class MakeUiTestCommand extends AbstractCommand
                 'jsdom'                     => '^26.0.0',
                 'react'                     => '^19.0.0',
                 'react-dom'                 => '^19.0.0',
+                'tailwindcss'               => '^4.0.0',
+                'tw-animate-css'            => '^1.2.0',
                 'typescript'                => '^5.7.0',
                 'vitest'                    => '^3.0.0',
             ],

--- a/modules/ground/src/Commands/PluginDevCommand.php
+++ b/modules/ground/src/Commands/PluginDevCommand.php
@@ -81,8 +81,16 @@ final class PluginDevCommand extends AbstractCommand
 
         $this->newLine();
         $this->info('Surfaces  : ' . implode(', ', $surfaces));
-        $this->info('Serving   : ' . $surface);
-        $this->info('Hot file  : ' . $dev->publicPath() . "/{$surface}-hot");
+
+        // EVERY surface goes hot, not just the one --mode names. One server
+        // serves them all, and PHP looks for the hot file of whichever surface
+        // the CONTROLLER named — so reporting a single one here described a
+        // setup where a page rendered on another surface silently got no
+        // scripts at all.
+        $this->info('Hot files : ' . implode(', ', array_map(
+            static fn(string $name): string => $name . '-hot',
+            $surfaces,
+        )) . '  in ' . $dev->publicPath());
 
         if (!is_dir($target->directory() . '/ui/node_modules')) {
             $this->newLine();

--- a/modules/ground/src/PluginManifest.php
+++ b/modules/ground/src/PluginManifest.php
@@ -140,6 +140,116 @@ final class PluginManifest
     }
 
     /**
+     * Every route with its prefixes, filters, requires and name RESOLVED —
+     * i.e. the paths a browser can actually be pointed at.
+     *
+     * {@see allRoutes()} flattens `groups[]` but deliberately leaves each entry
+     * as written, because its callers are checking declarations. Anything that
+     * NAVIGATES needs the other thing: a route declared `{"path": "/{id}"}`
+     * inside `{"prefix": "/admin"}` under `"routePrefix": "/api"` is served at
+     * `/api/admin/{id}`, and a tool that showed `/{id}` would be listing a URL
+     * that 404s.
+     *
+     * The inheritance rules are the compiler's, reproduced here because this is
+     * a READ of the same manifest and disagreeing with the compiler would be
+     * worse than not showing routes at all:
+     *
+     *   prefix    concatenated outward-in
+     *   name      concatenated outward-in, and an UNNAMED route stays unnamed
+     *   filters   merged, de-duplicated BY ALIAS — a route's `throttle:5,1`
+     *             replaces a group's `throttle:60,1` rather than adding to it
+     *   requires  union
+     *
+     * @return list<array{method: string, path: string, handler: string, name: ?string, filters: list<string>, requires: list<string>, dynamic: bool}>
+     */
+    public function expandedRoutes(): array
+    {
+        $out = [];
+
+        $inherited = [
+            'prefix'   => (string) ($this->data['routePrefix'] ?? ''),
+            'name'     => (string) ($this->data['routeName'] ?? ''),
+            'filters'  => array_map('strval', (array) ($this->data['routeFilters'] ?? [])),
+            'requires' => array_map('strval', (array) ($this->data['routeRequires'] ?? [])),
+        ];
+
+        $walk = function (array $node, array $inherited) use (&$walk, &$out): void {
+            foreach ($node['routes'] ?? [] as $route) {
+                if (!\is_array($route)) {
+                    continue;
+                }
+
+                $name = (string) ($route['name'] ?? '');
+                $path = $inherited['prefix'] . (string) ($route['path'] ?? '');
+
+                $out[] = [
+                    'method'   => strtoupper((string) ($route['method'] ?? 'GET')),
+                    // A module with no prefix and a route path of "" is the
+                    // module root, which is "/" and not the empty string.
+                    'path'     => $path === '' ? '/' : $path,
+                    'handler'  => (string) ($route['handler'] ?? ''),
+                    'name'     => $name === '' ? null : $inherited['name'] . $name,
+                    'filters'  => self::mergeFilters(
+                        $inherited['filters'],
+                        array_map('strval', (array) ($route['filters'] ?? [])),
+                    ),
+                    'requires' => array_values(array_unique([
+                        ...$inherited['requires'],
+                        ...array_map('strval', (array) ($route['requires'] ?? [])),
+                    ])),
+                    'dynamic'  => str_contains($path, '{'),
+                ];
+            }
+
+            foreach ($node['groups'] ?? [] as $group) {
+                if (!\is_array($group)) {
+                    continue;
+                }
+
+                $walk($group, [
+                    'prefix'   => $inherited['prefix'] . (string) ($group['prefix'] ?? ''),
+                    'name'     => $inherited['name'] . (string) ($group['name'] ?? ''),
+                    'filters'  => self::mergeFilters(
+                        $inherited['filters'],
+                        array_map('strval', (array) ($group['filters'] ?? [])),
+                    ),
+                    'requires' => array_values(array_unique([
+                        ...$inherited['requires'],
+                        ...array_map('strval', (array) ($group['requires'] ?? [])),
+                    ])),
+                ]);
+            }
+        };
+
+        $walk($this->data, $inherited);
+
+        return $out;
+    }
+
+    /**
+     * Outer filters, then inner, de-duplicated by ALIAS.
+     *
+     * `throttle:60,1` and `throttle:5,1` are the same filter configured twice,
+     * not two filters — listing both would say a route runs the stage twice,
+     * which is the bug the compiler's own de-duplication exists to prevent.
+     *
+     * @param list<string> $outer
+     * @param list<string> $inner
+     * @return list<string>
+     */
+    private static function mergeFilters(array $outer, array $inner): array
+    {
+        $byAlias = [];
+
+        foreach ([...$outer, ...$inner] as $filter) {
+            $alias           = strtok($filter, ':');
+            $byAlias[$alias] = $filter;
+        }
+
+        return array_values($byAlias);
+    }
+
+    /**
      * Module domains required by INDIVIDUAL routes or groups, rather than by the
      * module as a whole.
      *

--- a/modules/ground/src/Ui/DevWorkspace.php
+++ b/modules/ground/src/Ui/DevWorkspace.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AlfacodeTeam\Ground\Ui;
 
 use AlfacodeTeam\Ground\Inspection\PluginLocator;
+use AlfacodeTeam\Ground\PluginManifest;
 
 /**
  * `yarn dev` inside a plugin — the React UI, with HMR, against the real kernel.
@@ -55,17 +56,46 @@ final class DevWorkspace
         public readonly UiWorkspace $workspace,
         /** @var list<string> surface names from ui.json */
         public readonly array $surfaces,
+        /** The plugin's module.json, for the bench's route list. Null if unreadable. */
+        public readonly ?PluginManifest $manifest,
     ) {}
 
     public static function for(string $pluginDirectory, PluginLocator $locator): self
     {
         $ui = UiManifest::for($pluginDirectory);
 
+        // The bench lists the plugin's routes, so it needs module.json. Ask the
+        // locator first — it carries the real Provider class — and read the file
+        // directly only when the plugin is outside its scan.
+        //
+        // Either way a failure is swallowed: a malformed manifest must not stop
+        // the dev server being generated. Losing the route panel is a smaller
+        // problem than being unable to look at the plugin at all, and reporting
+        // a bad manifest is `ground check`'s job, not this one's.
+        $directory = rtrim($pluginDirectory, '/');
+        $manifest  = null;
+
+        foreach ($locator->all() as $candidate) {
+            if ($candidate->directory() === $directory) {
+                $manifest = $candidate;
+                break;
+            }
+        }
+
+        if ($manifest === null) {
+            try {
+                $manifest = PluginManifest::fromPath(\stdClass::class, $directory . '/module.json');
+            } catch (\InvalidArgumentException) {
+                // reported elsewhere
+            }
+        }
+
         return new self(
             rtrim($pluginDirectory, '/'),
             $ui,
             UiWorkspace::for($pluginDirectory, $locator),
             array_keys($ui->surfaces()),
+            $manifest,
         );
     }
 
@@ -94,6 +124,17 @@ final class DevWorkspace
         // would start and then fail to resolve on the first page load.
         if (!isset($this->workspace->aliases['@pageflow/react'])) {
             return 'the pageflow plugin was not found beside this one, so @pageflow/react cannot resolve';
+        }
+
+        // The generated entry imports AdminLayout as the DEFAULT layout, so the
+        // admin export is now a hard requirement of the entry itself — not only
+        // of the pages that happen to import it. Reported separately from
+        // @pageflow/react because an older pageflow checkout can have one export
+        // and not the other, and "@pageflow/react cannot resolve" would then be
+        // a false explanation of a real failure.
+        if (!isset($this->workspace->aliases['@pageflow/admin'])) {
+            return 'the pageflow checkout beside this one exports no @pageflow/admin, '
+                . 'so the generated entry cannot import the admin shell';
         }
 
         return null;
@@ -132,10 +173,17 @@ final class DevWorkspace
         $dir     = $this->directory();
 
         @mkdir($dir . '/src/surfaces', 0o775, true);
+        @mkdir($dir . '/src/styles', 0o775, true);
         @mkdir($this->publicPath(), 0o775, true);
 
         file_put_contents($dir . '/vite.config.ts', $this->viteConfig());
         $written[] = self::DIRECTORY . '/vite.config.ts';
+
+        file_put_contents($dir . '/src/styles/index.css', $this->stylesheet());
+        $written[] = self::DIRECTORY . '/src/styles/index.css';
+
+        file_put_contents($dir . '/src/ground.manifest.ts', $this->benchManifest());
+        $written[] = self::DIRECTORY . '/src/ground.manifest.ts';
 
         foreach ($this->surfaces as $surface) {
             $entryDir = $dir . '/src/surfaces/' . $surface;
@@ -201,6 +249,7 @@ final class DevWorkspace
         // adding a plugin.
         import { defineConfig } from "vite";
         import react from "@vitejs/plugin-react";
+        import tailwindcss from "@tailwindcss/vite";
         import fs from "node:fs";
         import { fileURLToPath } from "node:url";
         import { resolve } from "node:path";
@@ -223,15 +272,45 @@ final class DevWorkspace
          * left behind by a Ctrl-C points PHP at a dev server that is no longer
          * listening, and every page then loads a script that never answers.
          */
-        function hotFile(surface: string) {
-          const file = resolve(here("public"), `${surface}-hot`);
-          let removed = false;
+        /*
+         * A hot file for EVERY declared surface, not only the active mode.
+         *
+         * `--mode` picks which surface is primary; it does not limit what this
+         * server can serve, because every entry lives under the same root and
+         * Vite resolves them all. PHP, meanwhile, looks for `{surface}-hot` for
+         * whichever surface the CONTROLLER named — so a plugin whose pages
+         * render on `site` got no script tags at all while `yarn dev` sat there
+         * reporting itself ready on `admin`. The page came back as a bare shell
+         * with an empty #app and nothing anywhere said why.
+         *
+         * One server, every surface hot. Which one `--mode` selected is now
+         * only a label in the log line.
+         */
+        function hotFile(surfaces: string[]) {
+          const files = surfaces.map((s) => resolve(here("public"), `${s}-hot`));
+
+          /*
+           * Only THIS process's own hot file is ever removed.
+           *
+           * The cleanup used to be armed in configureServer, which runs before
+           * the server binds. With strictPort, a second `yarn dev` on a port
+           * already in use exits during startup — and on the way out deleted the
+           * hot file belonging to the server that was running perfectly well.
+           * PHP then stopped emitting any script tag at all, so every page came
+           * back as a bare shell with an empty #app: no error, no console
+           * message, just a blank document that looks like the app is broken.
+           *
+           * So ownership is claimed only once we are actually listening, and
+           * everything below is a no-op until then.
+           */
+          let owned = false;
 
           const clean = () => {
-            if (!removed && fs.existsSync(file)) {
+            if (!owned) return;
+            owned = false;
+            for (const file of files) {
               fs.rmSync(file, { force: true });
             }
-            removed = true;
           };
 
           return {
@@ -244,31 +323,42 @@ final class DevWorkspace
                 const protocol = server.config.server.https ? "https" : "http";
 
                 fs.mkdirSync(here("public"), { recursive: true });
-                fs.writeFileSync(file, `${protocol}://127.0.0.1:${port}`);
+                for (const file of files) {
+                  fs.writeFileSync(file, `${protocol}://127.0.0.1:${port}`);
+                }
+                owned = true;
+
+                // Armed HERE, not in configureServer, so a start that never
+                // bound cannot tear down somebody else's session on its way out.
+                for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+                  process.once(signal, () => {
+                    clean();
+                    process.exit();
+                  });
+                }
+                process.once("exit", clean);
 
                 server.config.logger.info(
-                  `\n  ground: ${surface} is hot — PHP will load modules from this server.\n`,
+                  `\n  ground: ${surfaces.join(", ")} hot — PHP will load modules from this server.\n`,
                 );
               });
-
-              for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
-                process.once(signal, () => {
-                  clean();
-                  process.exit();
-                });
-              }
-              process.once("exit", clean);
             },
             closeBundle: clean,
           };
         }
 
-        export default defineConfig(({ mode }) => {
-          const surface = SURFACES.includes(mode) ? mode : SURFACES[0];
-
+        // `--mode` no longer selects anything: one server serves every surface's
+        // entry and marks them all hot. It is kept because `ground dev` passes
+        // it and it still names the run in Vite's own output.
+        export default defineConfig(() => {
           return {
             root: here("."),
-            plugins: [react(), hotFile(surface)],
+            // Tailwind is not optional here. The pages, the shared @ui kit and
+            // @pageflow/admin's shell are ALL Tailwind-only — they carry no CSS
+            // of their own — so without this plugin every page under `yarn dev`
+            // renders as unstyled HTML, which reads like the component is broken
+            // rather than like the stylesheet is missing.
+            plugins: [react(), tailwindcss(), hotFile(SURFACES)],
 
             // esbuild otherwise walks up looking for the nearest tsconfig.json,
             // which outside a project is some other package's. Declaring the
@@ -325,20 +415,257 @@ final class DevWorkspace
     }
 
     /**
+     * The one stylesheet every generated entry imports.
+     *
+     * ─── WHY IT IS INLINED RATHER THAN IMPORTED ─────────────────────────────
+     *
+     * The obvious version is `@import "@shared/styles/theme.css"`, the way a
+     * project's surface does it. It does not work here. That file opens with
+     * `@import "tailwindcss"`, which resolves by walking up from the file that
+     * imports it — the KERNEL's templates/frontend, whose node_modules a plugin
+     * author has no reason to have installed. Inlining the theme's BODY and
+     * importing tailwindcss from a file inside `ui/.ground/` instead makes the
+     * lookup land in `ui/node_modules`, which `ground install` did populate.
+     *
+     * The theme is READ at generate time rather than copied into this class, so
+     * there is still exactly one definition of the tokens. The whole directory
+     * is regenerated on every run, so it cannot go stale against the kernel.
+     *
+     * ─── WHY THE @source LINES ARE NOT OPTIONAL ─────────────────────────────
+     *
+     * Tailwind v4 discovers classes by scanning outward from the stylesheet,
+     * and stops at .gitignore'd directories. Every file that matters here is
+     * outside that scan: the pages sit above a gitignored `.ground/`, and the
+     * @ui kit and @pageflow/admin shell are in sibling CHECKOUTS reached by
+     * alias. Without the explicit sources the build succeeds and emits a
+     * stylesheet containing none of the classes the shell uses — the failure
+     * being a bare-looking page, not an error.
+     */
+    private function stylesheet(): string
+    {
+        // …/.ground/src/styles/index.css is what the @source paths are relative to.
+        $from = $this->directory() . '/src/styles';
+
+        $sources = [];
+
+        // The plugin's own tree, one entry per top-level directory rather than
+        // a single glob over ui/. An explicit @source is taken literally —
+        // unlike Tailwind's automatic detection it does NOT skip node_modules —
+        // so `@source "../../../**"` would walk every installed package on
+        // every rebuild.
+        foreach (glob($this->ui->directory . '/*', GLOB_ONLYDIR) ?: [] as $face) {
+            if (\in_array(basename($face), ['node_modules', '.ground'], true)) {
+                continue;
+            }
+
+            $sources[] = $this->source($from, $face);
+        }
+
+        // The shell and the kit, by the same aliases the pages import them by,
+        // so this follows a checkout that moves instead of guessing at one.
+        // The bench's own chrome is Tailwind too, and it lives in a THIRD tree
+        // (this package) that neither the plugin's sources nor the aliases
+        // above reach.
+        $bench = $this->workspace->aliases['@ground/dev'] ?? null;
+        if ($bench !== null) {
+            $sources[] = $this->source($from, \dirname($bench));
+        }
+
+        foreach (['@pageflow/admin', '@ui'] as $alias) {
+            $path = $this->workspace->aliases[$alias] ?? null;
+
+            if ($path === null) {
+                continue;
+            }
+
+            // An export alias names a FILE (admin/index.ts); scan its directory.
+            $dir = is_dir($path) ? $path : \dirname($path);
+
+            $sources[] = $this->source($from, $dir);
+        }
+
+        return "/*\n"
+            . " * GENERATED by `hkm ground dev`. Gitignored.\n"
+            . " *\n"
+            . " * The kernel's shared theme, inlined — see DevWorkspace::stylesheet() for\n"
+            . " * why it is not an @import. Edit the kernel's\n"
+            . " * templates/frontend/src/shared/styles/theme.css and re-run the command.\n"
+            . " */\n"
+            . "@import \"tailwindcss\";\n"
+            . "@import \"tw-animate-css\";\n\n"
+            . implode("\n", $sources) . "\n\n"
+            . $this->sharedTheme() . "\n";
+    }
+
+    /**
+     * What the bench knows about this plugin, as a TypeScript module.
+     *
+     * GENERATED rather than fetched. The alternative is an endpoint the bench
+     * calls on load, and it would be wrong twice over: `ground serve` boots a
+     * fresh kernel per request, so there is no process holding this to be
+     * asked, and the data is static anyway — it is the manifest on disk, which
+     * this command has already read. Writing it out means the bench needs no
+     * server round-trip, works with the dev server alone, and cannot drift,
+     * because the whole workspace is regenerated on every run.
+     *
+     * A page is matched to a route by its handler naming the component; when
+     * nothing matches, `path` is null and the bench shows it as unreachable
+     * rather than offering a link that 404s.
+     */
+    private function benchManifest(): string
+    {
+        $routes = $this->manifest?->expandedRoutes() ?? [];
+
+        $pages = [];
+        foreach (['admin', 'site'] as $face) {
+            foreach ($this->ui->pageFilesFor($face) as $file) {
+                $component = preg_replace('#^.*/' . $face . '/Pages/#', '', substr($file, 0, -4)) ?? '';
+
+                if ($component === '') {
+                    continue;
+                }
+
+                $pages[] = [
+                    'component' => $component,
+                    'face'      => $face,
+                    'path'      => self::pathRendering($component, $routes),
+                ];
+            }
+        }
+
+        $manifest = [
+            'name'     => $this->manifest?->name() ?? basename($this->pluginDirectory),
+            'solves'   => $this->manifest?->solves() ?? '',
+            'requires' => $this->manifest?->requires() ?? [],
+            'exposes'  => $this->manifest?->exposes() ?? [],
+            'emits'    => $this->manifest?->emits() ?? [],
+            'surfaces' => $this->ui->surfaces(),
+            'pages'    => $pages,
+            'routes'   => $routes,
+        ];
+
+        return "// GENERATED by `hkm ground dev`. Gitignored — regenerated every run.\n"
+            . "import type { GroundManifest } from \"@ground/dev\";\n\n"
+            . 'export const manifest: GroundManifest = '
+            . json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+            . ";\n";
+    }
+
+    /**
+     * A GET route whose handler renders this component, or null.
+     *
+     * Matched on the handler's METHOD name against the component's last
+     * segment, which is the convention every plugin here follows
+     * (`UserController@index` → `User/Index`) — and checked case-insensitively,
+     * because the controller method is camelCase and the component is not.
+     *
+     * Deliberately conservative. A wrong link sends you to another page and
+     * looks like the page you asked for is broken; "no route" is at worst a
+     * missing convenience, and the bench says which it is.
+     *
+     * @param list<array{method: string, path: string, handler: string, dynamic: bool}> $routes
+     */
+    private static function pathRendering(string $component, array $routes): ?string
+    {
+        $leaf = strtolower(substr($component, (int) strrpos('/' . $component, '/')));
+
+        foreach ($routes as $route) {
+            if ($route['method'] !== 'GET' || $route['dynamic']) {
+                continue;
+            }
+
+            $at = strrpos($route['handler'], '@');
+
+            if ($at !== false && strtolower(substr($route['handler'], $at + 1)) === $leaf) {
+                return $route['path'];
+            }
+        }
+
+        return null;
+    }
+
+    /** One `@source` directive for a directory, relative to the stylesheet. */
+    private function source(string $from, string $directory): string
+    {
+        return '@source ' . json_encode(
+            UiWorkspace::relative($from, $directory) . '/**/*.{ts,tsx}',
+            JSON_UNESCAPED_SLASHES,
+        ) . ';';
+    }
+
+    /**
+     * The kernel theme's body — everything but its own two `@import` lines,
+     * which {@see stylesheet()} re-emits from a resolvable location.
+     *
+     * Returns a minimal stand-in when the template is not on disk (an installed
+     * bundle without it). A page then renders with Tailwind's utilities and no
+     * design tokens, which is degraded but legible — better than a build that
+     * fails on a missing file the author cannot supply.
+     */
+    private function sharedTheme(): string
+    {
+        $path = ($this->workspace->aliases['@shared'] ?? '') . '/styles/theme.css';
+
+        if (!is_file($path)) {
+            return ":root { --radius: 0.5rem; }";
+        }
+
+        $css = (string) file_get_contents($path);
+
+        return trim(preg_replace('/^@import\s+"(tailwindcss|tw-animate-css)";\s*$/m', '', $css) ?? $css);
+    }
+
+    /**
      * One surface's entry point.
      *
      * Mirrors what a project's own `src/surfaces/<name>/index.tsx` does, so a
      * page behaves here the way it will there: same component-key convention,
      * same ThemeProvider, same boot from `data-page` with the legacy
      * `window.initialPage` fallback.
+     *
+     * ─── WITH ONE DELIBERATE DIFFERENCE: THE DEFAULT LAYOUT ─────────────────
+     *
+     * Pageflow's <App> applies `Component.layout` and, when a page declares
+     * none, renders the page bare. That is right in production — a public page
+     * has no admin chrome — but under `ground dev` it means a page whose author
+     * simply has not written the one-line `.layout` assignment yet opens as
+     * unstyled markup on a white document, which reads like the page is broken.
+     *
+     * So this entry passes <App> the `children` render-prop, which REPLACES its
+     * default renderChildren, and falls back to <AdminLayout>. A page that
+     * declares its own layout keeps it — the fallback is only reached when
+     * there is nothing to honour.
+     *
+     * The function must not call hooks. <App> invokes it INLINE during its own
+     * render, so a hook there joins App's hook list, and App's hook count then
+     * varies with whichever page is mounted — React throws "rendered more hooks
+     * than during the previous render" on the first navigation between a page
+     * that has a layout and one that does not.
      */
     private function surfaceEntry(string $surface): string
     {
         $template = <<<'TSX'
         // GENERATED by `hkm ground dev` for the "__SURFACE__" surface. Gitignored.
+        import "../../styles/index.css";
+        import { createElement } from "react";
         import { createRoot } from "react-dom/client";
         import { createPageflowApp } from "@pageflow/react";
+        import { GroundFrame } from "@ground/dev";
         import { ThemeProvider } from "@providers/theme";
+        import { manifest } from "../../ground.manifest";
+
+        /*
+         * The plugin's nav contributions, imported for their SIDE EFFECT.
+         *
+         * `ui/admin/nav.ts` calls registerModule()/registerFeature() at import
+         * time, and nothing had ever imported it — not this entry, and not the
+         * kernel's own surface template, though @pageflow/admin's README says
+         * the surface globs it. So the registry was empty everywhere and the
+         * sidebar could not be made to show a single item. Eager, because a
+         * registration that has not run by first paint is a nav that renders
+         * empty and then jumps.
+         */
+        import.meta.glob("../../../../admin/nav.ts", { eager: true });
 
         /*
          * Every page under this plugin's surfaces, lazily imported.
@@ -377,13 +704,36 @@ final class DevWorkspace
         const legacyPage = (window as unknown as { initialPage?: unknown }).initialPage;
         const initialPage = el.dataset.page ? JSON.parse(el.dataset.page) : (legacyPage ?? {});
 
+        /*
+         * Replaces <App>'s own renderChildren so every page opens on the bench.
+         *
+         * GroundFrame decides the layout — honouring the page's own `.layout`
+         * and falling back to the admin shell by default, or forcing one when
+         * the bar says so. It renders the page UNTOUCHED inside its chrome, so
+         * what is on screen is still what a project renders.
+         *
+         * NO HOOKS IN HERE. App calls this inline during its own render, so a
+         * hook would join App's hook list and the count would then change with
+         * whichever page is mounted — React throws "rendered more hooks than
+         * during the previous render" on the first navigation between a page
+         * that has a layout and one that does not. GroundFrame is a COMPONENT,
+         * so its own hooks are its own; this function must stay a plain call.
+         */
+        function renderPage({ Component, props, key }: { Component: any; props: any; key: any }) {
+          return (
+            <GroundFrame manifest={manifest} component={Component}>
+              {createElement(Component, { key, ...props })}
+            </GroundFrame>
+          );
+        }
+
         createPageflowApp({
           page: initialPage,
           resolve: resolveComponent,
           setup({ el, App, props }: { el: HTMLElement; App: any; props: any }) {
             createRoot(el).render(
               <ThemeProvider>
-                <App {...props} />
+                <App {...props}>{renderPage}</App>
               </ThemeProvider>,
             );
           },

--- a/modules/ground/src/Ui/UiWorkspace.php
+++ b/modules/ground/src/Ui/UiWorkspace.php
@@ -88,6 +88,16 @@ final class UiWorkspace
             }
         }
 
+        // Ground's own dev bench. It belongs HERE rather than in DevWorkspace
+        // because both generated configs need it: the dev server's, and the
+        // VITEST one — a test that boots the generated entry (which imports the
+        // bench) otherwise fails to resolve it, and the message names the entry
+        // rather than the missing alias.
+        $bench = self::benchPath();
+        if ($bench !== null) {
+            $aliases['@ground/dev'] = $bench;
+        }
+
         $shared = self::sharedKitPath();
         if ($shared !== null) {
             // The template's own alias list, from vite/aliases.ts
@@ -137,6 +147,31 @@ final class UiWorkspace
         }
 
         return new self($aliases, $dependencies);
+    }
+
+    /**
+     * Ground's own `ui/dev` — the bench the generated entry frames pages with.
+     *
+     * Found by reflection for the same reason {@see sharedKitPath} does it:
+     * this package runs from a kernel checkout, an installed bundle and a
+     * plugin's vendor/, and the hop count to its root differs in each.
+     *
+     * It cannot come from the locator. The locator globs `*<slash>module.json`
+     * one level down, and ground keeps its manifest at `src/module.json` — so
+     * ground never appears in its own scan and would never be aliased.
+     */
+    public static function benchPath(): ?string
+    {
+        $file = (new \ReflectionClass(self::class))->getFileName();
+
+        if ($file === false) {
+            return null;
+        }
+
+        // …/modules/ground/src/Ui/UiWorkspace.php → …/modules/ground
+        $dev = \dirname($file, 3) . '/ui/dev';
+
+        return is_file($dev . '/index.ts') ? $dev . '/index.ts' : null;
     }
 
     /**
@@ -259,8 +294,15 @@ final class UiWorkspace
         return implode("\n", $lines);
     }
 
-    /** $to expressed relative to $from, with `../` hops. */
-    private static function relative(string $from, string $to): string
+    /**
+     * $to expressed relative to $from, with `../` hops.
+     *
+     * Public because {@see DevWorkspace} generates a stylesheet whose `@source`
+     * directives have to reach the same sibling checkouts these aliases point
+     * at, and re-deriving the hop count there would be a second implementation
+     * of this that drifts the first time the workspace layout changes.
+     */
+    public static function relative(string $from, string $to): string
     {
         $fromParts = explode('/', trim($from, '/'));
         $toParts   = explode('/', trim($to, '/'));

--- a/modules/ground/tests/DevWorkspaceTest.php
+++ b/modules/ground/tests/DevWorkspaceTest.php
@@ -29,9 +29,26 @@ final class DevWorkspaceTest extends TestCase
         mkdir($this->plugin . '/ui/site/Pages', 0o775, true);
 
         file_put_contents($this->plugin . '/module.json', json_encode([
-            'name'   => 'sample',
-            'solves' => 'sample.domain',
-            'type'   => 'module',
+            'name'         => 'sample',
+            'solves'       => 'sample.domain',
+            'type'         => 'module',
+            'requires'     => ['database.management'],
+            'routePrefix'  => '/api',
+            'routeFilters' => ['auth'],
+            'routes'       => [
+                ['method' => 'GET', 'path' => '/things', 'handler' => 'X\\ThingController@index'],
+            ],
+            'groups'       => [
+                [
+                    'prefix'  => '/admin',
+                    'name'    => 'sample.admin.',
+                    'filters' => ['throttle:60,1'],
+                    'routes'  => [
+                        ['method' => 'GET', 'path' => '/audit', 'handler' => 'X\\AuditController@audit', 'name' => 'audit'],
+                        ['method' => 'GET', 'path' => '/things/{id:num}', 'handler' => 'X\\ThingController@show'],
+                    ],
+                ],
+            ],
         ]));
 
         file_put_contents($this->plugin . '/ui/ui.json', json_encode([
@@ -197,11 +214,460 @@ final class DevWorkspaceTest extends TestCase
         self::assertStringContainsString('Pages', (string) $dev->unsupportedReason());
     }
 
+    /**
+     * A page that declares NO layout still opens inside the admin shell.
+     *
+     * Pageflow's <App> renders such a page bare. That is right in production —
+     * a public page has no admin chrome — and wrong on the bench, where the
+     * author is looking at the page to find out whether it works and a
+     * chromeless white document reads like the page is broken rather than like
+     * the one-line `.layout` assignment has not been written yet.
+     *
+     * Asserted against the bench source, because that is where the decision
+     * moved when the frame took it over. The behaviour itself is covered by the
+     * plugin-side vitest suite, which mounts the real components.
+     */
+    public function testAPageWithoutItsOwnLayoutStillGetsTheAdminShell(): void
+    {
+        $frame = $this->benchSource('GroundFrame.tsx');
+
+        self::assertStringContainsString(
+            '<AdminLayout>{child}</AdminLayout>',
+            $frame,
+            'A page declaring no layout must fall back to the admin shell.',
+        );
+        self::assertStringContainsString(
+            '(layout as (node: ReactNode) => ReactNode)(child)',
+            $frame,
+            "A page's OWN layout must still win over the fallback.",
+        );
+        self::assertStringContainsString(
+            'Array.isArray(layout)',
+            $frame,
+            'Pageflow also accepts an array of layouts; dropping that form would change behaviour under the bench.',
+        );
+    }
+
+    /**
+     * A site page renders the way a PROJECT renders it: bare.
+     *
+     * The fallback used to apply on both faces, which put an admin sidebar,
+     * a breadcrumb and a clock around `/register` — chrome no deployment of
+     * that page has ever had. It is the exact failure the frame exists to avoid
+     * in the other direction: the bench stopped showing what the browser shows.
+     *
+     * The admin face keeps the fallback, because there the alternative is
+     * unstyled markup on a white document, which reads like the page is broken
+     * rather than like its one-line `.layout` has not been written yet.
+     */
+    public function testTheFallbackIsFaceAware(): void
+    {
+        $frame = $this->benchSource('GroundFrame.tsx');
+
+        self::assertStringContainsString(
+            'face === "site" ? child : <AdminLayout>{child}</AdminLayout>',
+            $frame,
+            'A site/Pages page must fall back to nothing, an admin/Pages page to the shell.',
+        );
+
+        // The face comes from the generated manifest, which already records it
+        // per page — not from a second convention invented in the frame.
+        self::assertStringContainsString(
+            'manifest.pages.find((candidate) => candidate.component === page.component)?.face',
+            $frame,
+        );
+        self::assertStringContainsString(
+            '?? "admin"',
+            $frame,
+            'An unclassified component keeps the shell; guessing "site" reintroduces the unstyled-markup case.',
+        );
+    }
+
+    /**
+     * The entry imports a stylesheet, and that stylesheet loads Tailwind.
+     *
+     * The pages, the shared @ui kit and @pageflow/admin's shell carry no CSS of
+     * their own — they are Tailwind-only. Without this the dev server starts,
+     * the page renders, and every class in it resolves to nothing.
+     */
+    public function testTheGeneratedEntryHasAStylesheetToImport(): void
+    {
+        $this->workspace()->generate();
+
+        $css = $this->plugin . '/ui/.ground/src/styles/index.css';
+
+        self::assertFileExists($css);
+
+        $contents = (string) file_get_contents($css);
+
+        self::assertStringContainsString('@import "tailwindcss";', $contents);
+
+        foreach (['admin', 'site'] as $surface) {
+            $entry = (string) file_get_contents($this->plugin . "/ui/.ground/src/surfaces/{$surface}/index.tsx");
+
+            self::assertStringContainsString('import "../../styles/index.css";', $entry);
+        }
+
+        // The path in that import has to resolve, not merely look plausible.
+        self::assertFileExists($this->plugin . '/ui/.ground/src/surfaces/admin/../../styles/index.css');
+    }
+
+    /**
+     * The shell's chrome tokens are in the stylesheet the entry loads.
+     *
+     * @pageflow/admin's shell names eleven `--sidebar-*` custom properties
+     * (`bg-sidebar-bg`, `text-sidebar-fg-muted`, `w-[var(--sidebar-width)]`, …).
+     * They were defined nowhere for a while — the shell was ported out of HKM
+     * 0.3 and its stylesheet was left behind — so the sidebar rendered
+     * transparent with no width. That is invisible to every build: an undefined
+     * custom property is not an error.
+     */
+    public function testTheSidebarTokensTheShellReadsAreDefined(): void
+    {
+        $this->workspace()->generate();
+
+        $css = (string) file_get_contents($this->plugin . '/ui/.ground/src/styles/index.css');
+
+        foreach ([
+            'bg', 'fg', 'fg-muted', 'fg-active', 'border', 'hover', 'active', 'section',
+        ] as $token) {
+            self::assertStringContainsString("--sidebar-{$token}:", $css, "--sidebar-{$token} is unset.");
+            self::assertStringContainsString(
+                "--color-sidebar-{$token}: hsl(var(--sidebar-{$token}));",
+                $css,
+                "sidebar-{$token} has a value but no Tailwind utility maps onto it.",
+            );
+        }
+
+        self::assertStringContainsString('--sidebar-width:', $css);
+        self::assertStringContainsString('@utility sidebar-transition', $css);
+    }
+
+    /**
+     * The `@source` directives reach the code, and stop short of node_modules.
+     *
+     * Tailwind v4 scans outward from the stylesheet and stops at gitignored
+     * directories, so nothing that matters here is found automatically: the
+     * pages sit above a gitignored `.ground/`, and the kit and the shell are in
+     * sibling checkouts. But an EXPLICIT @source is taken literally and does not
+     * skip node_modules — so a single `@source "../../../**"` would walk every
+     * installed package on every rebuild.
+     */
+    public function testSourceDirectivesReachThePagesWithoutWalkingNodeModules(): void
+    {
+        mkdir($this->plugin . '/ui/node_modules/react', 0o775, true);
+
+        $this->workspace()->generate();
+
+        $base = $this->plugin . '/ui/.ground/src/styles';
+        $css  = (string) file_get_contents($base . '/index.css');
+
+        preg_match_all('/@source "([^"]+)";/', $css, $matches);
+
+        self::assertNotEmpty($matches[1], 'Without an @source, Tailwind emits none of the shell\'s classes.');
+
+        $resolved = [];
+        foreach ($matches[1] as $glob) {
+            $prefix = substr($glob, 0, (int) strpos($glob, '/**/'));
+
+            self::assertStringNotContainsString(
+                'node_modules',
+                $prefix,
+                'An explicit @source is literal — it would scan every installed package.',
+            );
+
+            $dir = realpath($base . '/' . $prefix);
+            if ($dir !== false) {
+                $resolved[] = $dir;
+            }
+        }
+
+        self::assertContains(
+            realpath($this->plugin . '/ui/admin'),
+            $resolved,
+            'The plugin\'s own pages have to be scanned, or their classes are purged.',
+        );
+    }
+
+    /**
+     * EVERY declared surface goes hot, not only the one `--mode` names.
+     *
+     * PHP looks for `{surface}-hot` for whichever surface the CONTROLLER named.
+     * A plugin whose pages render on `site` therefore got no script tags at all
+     * while `yarn dev` sat there reporting itself ready on `admin` — the page
+     * came back as a bare shell with an empty #app, no error anywhere, which is
+     * indistinguishable from the app being broken.
+     *
+     * One server serves every entry under the same root, so marking them all
+     * hot is honest rather than generous.
+     */
+    public function testEverySurfaceIsMarkedHotByOneServer(): void
+    {
+        $config = $this->generatedConfig();
+
+        self::assertStringContainsString('hotFile(SURFACES)', $config);
+        self::assertStringContainsString('surfaces.map((s) => resolve(here("public"), `${s}-hot`))', $config);
+        self::assertStringNotContainsString(
+            'hotFile(surface)',
+            $config,
+            'A single-surface hot file is what left site-rendered pages with no scripts.',
+        );
+    }
+
+    /**
+     * A dev server that never bound must not delete a running one's hot file.
+     *
+     * The cleanup used to be armed in configureServer, which runs BEFORE the
+     * port is bound. With strictPort, a second `yarn dev` on a taken port exits
+     * during startup — and on the way out removed the hot file belonging to the
+     * server that was working fine. PHP then stopped emitting any script tag,
+     * so every page went blank, and nothing connected that to the command
+     * someone had just run in another terminal.
+     */
+    public function testAFailedStartCannotClearARunningServersHotFile(): void
+    {
+        $config = $this->generatedConfig();
+
+        self::assertStringContainsString('let owned = false;', $config);
+        self::assertStringContainsString('if (!owned) return;', $config);
+
+        // Ownership is claimed inside the `listening` handler, and the process
+        // hooks are armed there too — after the bind, never before it.
+        $listening = substr($config, (int) strpos($config, 'once("listening"'));
+        $armed     = strpos($listening, 'process.once("exit", clean)');
+        $claimed   = strpos($listening, 'owned = true;');
+
+        self::assertNotFalse($armed, 'The exit hook must live inside the listening handler.');
+        self::assertNotFalse($claimed);
+        self::assertLessThan($armed, $claimed, 'Ownership is claimed before the teardown hooks are armed.');
+    }
+
+    /** Tailwind has to be a Vite plugin too, not only an @import. */
+    public function testTheViteConfigLoadsTailwind(): void
+    {
+        $this->workspace()->generate();
+
+        $config = (string) file_get_contents($this->plugin . '/ui/.ground/vite.config.ts');
+
+        self::assertStringContainsString('import tailwindcss from "@tailwindcss/vite";', $config);
+        self::assertStringContainsString('tailwindcss()', $config);
+    }
+
+    /**
+     * The bench is chrome AROUND the page, never a replacement for the shell.
+     *
+     * A ground-specific layout in place of the admin one would cost the single
+     * property that makes this package worth having: `ground serve` runs the
+     * real pipeline so that a page rendering here is a page the browser
+     * renders. So the entry hands the real component to the frame and the frame
+     * renders it untouched — it does not construct the page itself.
+     */
+    public function testTheEntryFramesThePageRatherThanReplacingItsLayout(): void
+    {
+        $this->workspace()->generate();
+
+        $entry = (string) file_get_contents($this->plugin . '/ui/.ground/src/surfaces/admin/index.tsx');
+
+        self::assertStringContainsString('import { GroundFrame } from "@ground/dev";', $entry);
+        self::assertStringContainsString('<GroundFrame manifest={manifest} component={Component}>', $entry);
+        self::assertStringContainsString('createElement(Component, { key, ...props })', $entry);
+    }
+
+    /**
+     * The plugin's nav.ts is imported for its side effect.
+     *
+     * `registerModule()` runs at import time and NOTHING had ever imported the
+     * file — not this entry and not the kernel's surface template, although the
+     * admin README says the surface globs it. The registry was therefore empty
+     * everywhere, and no configuration of any project could put an item in the
+     * sidebar.
+     */
+    public function testTheEntryImportsTheNavRegistration(): void
+    {
+        $this->workspace()->generate();
+
+        $entry = (string) file_get_contents($this->plugin . '/ui/.ground/src/surfaces/admin/index.tsx');
+
+        self::assertMatchesRegularExpression(
+            '/import\.meta\.glob\("[^"]*admin\/nav\.ts", \{ eager: true \}\)/',
+            $entry,
+            'Eager: a registration that has not run by first paint is a nav that renders empty and then jumps.',
+        );
+    }
+
+    /**
+     * The bench manifest carries paths a browser can be pointed at.
+     *
+     * Prefixes are the whole point. A route written `/things/{id:num}` inside
+     * `{"prefix": "/admin"}` under `"routePrefix": "/api"` is served at
+     * `/api/admin/things/{id:num}`, and a route list showing the declaration
+     * would be listing URLs that 404.
+     */
+    public function testTheBenchManifestResolvesPrefixesFiltersAndNames(): void
+    {
+        $this->workspace()->generate();
+
+        $manifest = $this->benchManifest();
+
+        $paths = array_column($manifest['routes'], 'path');
+        self::assertContains('/api/things', $paths);
+        self::assertContains('/api/admin/audit', $paths);
+        self::assertContains('/api/admin/things/{id:num}', $paths);
+
+        $audit = $this->routeFor($manifest, '/api/admin/audit');
+        self::assertSame('sample.admin.audit', $audit['name'], 'Group names concatenate outward-in.');
+        self::assertSame(['auth', 'throttle:60,1'], $audit['filters'], 'Module filters, then the group\'s.');
+        self::assertFalse($audit['dynamic']);
+
+        $show = $this->routeFor($manifest, '/api/admin/things/{id:num}');
+        self::assertNull($show['name'], 'An unnamed route stays unnamed, prefix or not.');
+        self::assertTrue($show['dynamic'], 'A parameterised path is not a URL and must not be offered as one.');
+    }
+
+    /**
+     * A page reachable by no route is listed, and says so.
+     *
+     * That is the case the bench exists for: with no URL to type, such a page
+     * could not be looked at in a browser at all without adding a throwaway
+     * route to module.json.
+     */
+    public function testPagesAreMatchedToTheRouteThatRendersThem(): void
+    {
+        file_put_contents($this->plugin . '/ui/admin/Pages/Thing/Orphan.tsx', 'export default () => null;');
+
+        $this->workspace()->generate();
+
+        $pages = [];
+        foreach ($this->benchManifest()['pages'] as $page) {
+            $pages[$page['component']] = $page['path'];
+        }
+
+        self::assertSame('/api/things', $pages['Thing/Index'], 'ThingController@index renders Thing/Index.');
+        self::assertNull($pages['Thing/Orphan'], 'No handler names it — the bench must not invent a link.');
+        self::assertArrayHasKey('Home', $pages, 'Site pages are listed too.');
+    }
+
+    /**
+     * The bench's own alias comes from UiWorkspace, so BOTH generated configs
+     * carry it.
+     *
+     * It cannot come from the locator: that globs `*&#47;module.json` one level
+     * down and ground keeps its manifest at `src/module.json`, so ground never
+     * appears in its own scan. When it lived in DevWorkspace instead, the dev
+     * server resolved `@ground/dev` and vitest did not — and the failure named
+     * the generated entry rather than the missing alias.
+     */
+    public function testTheBenchAliasIsPartOfTheSharedWorkspace(): void
+    {
+        $aliases = $this->workspace()->workspace->aliases;
+
+        self::assertArrayHasKey('@ground/dev', $aliases);
+        self::assertFileExists($aliases['@ground/dev']);
+
+        self::assertStringContainsString('"@ground/dev"', $this->generatedConfig());
+    }
+
+    /** The bench's own chrome is Tailwind, and lives in a third tree the plugin's sources never reach. */
+    public function testTheStylesheetScansTheBenchToo(): void
+    {
+        $this->workspace()->generate();
+
+        $base = $this->plugin . '/ui/.ground/src/styles';
+        $css  = (string) file_get_contents($base . '/index.css');
+
+        preg_match_all('/@source "([^"]+)";/', $css, $matches);
+
+        // Matched on the SUFFIX rather than resolved with realpath: the plugin
+        // here lives under sys_get_temp_dir(), which on macOS is /var/folders
+        // symlinked from /private/var, so a relative hop count computed against
+        // one spelling does not resolve against the other. That is an artefact
+        // of the temporary directory, not of the generated path — the real
+        // checkouts this runs against share a root.
+        $found = false;
+        foreach ($matches[1] as $glob) {
+            if (str_ends_with($glob, '/ui/dev/**/*.{ts,tsx}')) {
+                $found = true;
+            }
+        }
+
+        self::assertTrue($found, "Without this, every class in the bench's own chrome is purged.");
+        unset($base);
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private function workspace(): DevWorkspace
     {
         return DevWorkspace::for($this->plugin, new PluginLocator($this->plugin, includeSiblings: false));
+    }
+
+    /**
+     * A file from ground's own `ui/dev`, located the way the workspace locates
+     * it — by reflection, not by counting directories up from the test.
+     */
+    private function benchSource(string $file): string
+    {
+        $bench = \AlfacodeTeam\Ground\Ui\UiWorkspace::benchPath();
+
+        self::assertNotNull($bench, 'ground ships ui/dev; without it there is no bench to generate.');
+
+        $path = \dirname($bench) . '/' . $file;
+
+        self::assertFileExists($path);
+
+        return (string) file_get_contents($path);
+    }
+
+    private function generatedConfig(): string
+    {
+        $this->workspace()->generate();
+
+        return (string) file_get_contents($this->plugin . '/ui/.ground/vite.config.ts');
+    }
+
+    /**
+     * The generated ground.manifest.ts, decoded.
+     *
+     * It is a TypeScript module wrapping one JSON object literal, so the object
+     * is read back out rather than the file being parsed — asserting on the
+     * DATA is what these tests are about, and asserting on the wrapper would
+     * break on a comment change.
+     *
+     * @return array{name: string, routes: list<array<string, mixed>>, pages: list<array<string, mixed>>}
+     */
+    private function benchManifest(): array
+    {
+        $source = (string) file_get_contents($this->plugin . '/ui/.ground/src/ground.manifest.ts');
+
+        // Anchored past the `import type { GroundManifest }` line: its braces
+        // are the first in the file, so a naive strpos('{') reads the import.
+        $marker = 'export const manifest: GroundManifest = ';
+        $start  = strpos($source, $marker);
+
+        self::assertNotFalse($start, 'The manifest module must export `manifest`.');
+
+        $start += \strlen($marker);
+        $end    = strrpos($source, '}');
+
+        self::assertNotFalse($end);
+
+        $decoded = json_decode(substr($source, $start, $end - $start + 1), true);
+
+        self::assertIsArray($decoded, 'The generated manifest must be valid JSON inside the module.');
+
+        return $decoded;
+    }
+
+    /** @param array{routes: list<array<string, mixed>>} $manifest */
+    private function routeFor(array $manifest, string $path): array
+    {
+        foreach ($manifest['routes'] as $route) {
+            if ($route['path'] === $path) {
+                return $route;
+            }
+        }
+
+        self::fail("No route compiled to {$path}.");
     }
 
     private static function removeTree(string $path): void

--- a/modules/ground/ui/dev/GroundFrame.tsx
+++ b/modules/ground/ui/dev/GroundFrame.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useMemo, type ComponentType, type ReactNode } from "react";
+import { PageContext, usePage } from "@pageflow/react";
+import { AdminLayout, AuthLayout } from "@pageflow/admin";
+import { PagesPanel, RoutesPanel, InspectPanel, ShellPanel } from "./panels";
+import { useGroundState, type LayoutChoice, type PanelChoice, type ViewportChoice } from "./state";
+import { setSimulatedWidth, VIEWPORT_WIDTH } from "./viewport";
+import type { GroundManifest } from "./types";
+
+export interface GroundFrameProps {
+  manifest: GroundManifest;
+  /** The page component, read for its `.layout` — NOT rendered by the frame. */
+  component: ComponentType & { layout?: unknown };
+  /** The page element, already created by the entry. */
+  children: ReactNode;
+}
+
+/**
+ * The bench: dev chrome around a page, and nothing inside it.
+ *
+ * ─── WHY IT IS A FRAME AND NOT A LAYOUT ─────────────────────────────────────
+ *
+ * The tempting design is a "ground layout" that REPLACES the admin shell with
+ * something friendlier to develop against. It would also destroy the one
+ * property that makes this package worth having: `ground serve` runs the real
+ * HttpPipeline so that a page rendering here is a page the browser renders. Swap
+ * the shell for a bench-specific one and you are looking at chrome no project
+ * ships, which is exactly where the interesting bugs hide — the crash that
+ * started this frame was `AdminLayout` calling `matchMedia`, and no substitute
+ * layout would ever have found it.
+ *
+ * So the production tree is rendered UNTOUCHED, and the bench is chrome outside
+ * it. That also makes the layout a control rather than a decision: `page`
+ * (honour the page's own, fall back to the admin shell), `bare`, `admin`,
+ * `auth` — the same page, four ways, without editing it.
+ *
+ * ─── WHY THE CHROME IS `position: fixed` ────────────────────────────────────
+ *
+ * `AdminLayout` is `h-screen`, i.e. 100vh. Put a toolbar in normal flow above
+ * it and the shell is a toolbar's height taller than the window on every page,
+ * so the sidebar scrolls when it should not and the bench has introduced a
+ * layout bug of its own. Fixed chrome overlays instead: the page keeps the
+ * whole viewport and 100vh stays true.
+ */
+export function GroundFrame({ manifest, component, children }: GroundFrameProps) {
+  const page = usePage<Record<string, unknown>>();
+  const [state, patch] = useGroundState();
+
+  // The matchMedia shim installs itself when ./viewport is imported — it has to
+  // be ahead of the shell's own subscription, and React runs child effects
+  // before a parent's. All that is left here is telling it which width to
+  // report, and restoring the truth when the bench goes away.
+  useEffect(() => {
+    setSimulatedWidth(VIEWPORT_WIDTH[state.viewport]);
+    return () => setSimulatedWidth(null);
+  }, [state.viewport]);
+
+  /**
+   * The page object the tree below sees.
+   *
+   * Overriding `adminShell` through a NESTED PageContext, rather than by
+   * mutating the page, is what keeps this honest: `usePage` reads the nearest
+   * provider, so the shell picks the override up with no knowledge of the
+   * bench, and the real page object is still what the inspector shows and what
+   * the next navigation replaces.
+   */
+  const scoped = useMemo(() => {
+    if (state.shell === null) return page;
+
+    const props = (page.props ?? {}) as Record<string, unknown>;
+    const server = (props.adminShell ?? {}) as Record<string, unknown>;
+
+    return { ...page, props: { ...props, adminShell: { ...server, ...state.shell } } };
+  }, [page, state.shell]);
+
+  /**
+   * Which face this page was authored under, from the generated manifest.
+   *
+   * The layout fallback keys on it, so a `site/Pages` page renders the way a
+   * project renders it — bare — instead of wearing admin chrome it never has in
+   * production. An unknown component (not one this plugin ships) keeps the
+   * admin fallback: the point of having a fallback at all is that a page never
+   * opens as unstyled markup, and guessing "site" for something unclassified
+   * would reintroduce exactly that.
+   */
+  const face = useMemo(
+    () => manifest.pages.find((candidate) => candidate.component === page.component)?.face ?? "admin",
+    [manifest, page.component],
+  );
+
+  const shelled = applyLayout(state.layout, component, children, face);
+  const width = VIEWPORT_WIDTH[state.viewport];
+
+  return (
+    <PageContext.Provider value={scoped as never}>
+      <div
+        className={width === null ? "contents" : "flex min-h-screen justify-center bg-neutral-950 py-0"}
+        style={width === null ? undefined : { colorScheme: "normal" }}
+      >
+        <div
+          className={width === null ? "contents" : "h-screen overflow-hidden border-x border-neutral-800 shadow-2xl"}
+          style={width === null ? undefined : { width }}
+        >
+          {shelled}
+        </div>
+      </div>
+
+      <Chrome manifest={manifest} page={page} state={state} patch={patch} />
+    </PageContext.Provider>
+  );
+}
+
+/**
+ * `page` reproduces what a PROJECT would render, and nothing more.
+ *
+ * A page's own `.layout` wins, as it does everywhere. Failing that the fallback
+ * is face-aware: an `admin/Pages` page gets the admin shell, because opening it
+ * as unstyled markup reads like the page is broken rather than like the
+ * one-line `.layout` assignment has not been written yet — and a `site/Pages`
+ * page gets nothing, because that is what it gets in production. Falling back
+ * to the shell on both faces put an admin sidebar and a breadcrumb around
+ * /register, which is chrome no deployment of that page has ever had.
+ *
+ * The other three FORCE a layout. That is why the bar keeps showing which one
+ * is active, in amber when it is not `page`: a forced `bare` looks exactly like
+ * a page that has lost its layout.
+ */
+function applyLayout(
+    choice: LayoutChoice,
+    component: GroundFrameProps["component"],
+    child: ReactNode,
+    face: string,
+): ReactNode {
+  if (choice === "bare") return child;
+  if (choice === "admin") return <AdminLayout>{child}</AdminLayout>;
+  if (choice === "auth") return <AuthLayout>{child}</AuthLayout>;
+
+  const layout = component.layout;
+
+  if (typeof layout === "function") return (layout as (node: ReactNode) => ReactNode)(child);
+
+  // Pageflow also accepts an ARRAY of nested layout components. Reproduced from
+  // App's own renderChildren rather than dropped, so a page using that form
+  // behaves under the bench exactly as it does in a project.
+  if (Array.isArray(layout)) {
+    return layout
+      .concat(child as never)
+      .reverse()
+      .reduce((children: ReactNode, Layout: ComponentType<{ children: ReactNode }>) => (
+        <Layout>{children}</Layout>
+      ));
+  }
+
+  return face === "site" ? child : <AdminLayout>{child}</AdminLayout>;
+}
+
+// ── The chrome ────────────────────────────────────────────────────────────────
+
+const PANELS: { id: PanelChoice; label: string }[] = [
+  { id: "pages", label: "Pages" },
+  { id: "routes", label: "Routes" },
+  { id: "inspect", label: "Page object" },
+  { id: "shell", label: "adminShell" },
+];
+
+const LAYOUTS: { id: LayoutChoice; label: string; title: string }[] = [
+  {
+    id: "page",
+    label: "page",
+    title:
+      "What a project renders: the page's own .layout, else the admin shell for an admin/Pages page and nothing for a site/Pages one",
+  },
+  { id: "bare", label: "bare", title: "No layout at all" },
+  { id: "admin", label: "admin", title: "Force AdminLayout" },
+  { id: "auth", label: "auth", title: "Force AuthLayout" },
+];
+
+const VIEWPORTS: { id: ViewportChoice; label: string; title: string }[] = [
+  { id: "full", label: "▭", title: "The real window" },
+  { id: "tablet", label: "▯", title: "Tablet — 834px, and matchMedia answers as one" },
+  { id: "mobile", label: "▮", title: "Phone — 390px, so the shell renders its mobile drawer" },
+];
+
+function Chrome({
+  manifest,
+  page,
+  state,
+  patch,
+}: {
+  manifest: GroundManifest;
+  page: { component?: string; url?: string; props?: unknown };
+  state: ReturnType<typeof useGroundState>[0];
+  patch: ReturnType<typeof useGroundState>[1];
+}) {
+  const path = useMemo(() => {
+    try {
+      return new URL(page.url ?? "/", window.location.origin).pathname;
+    } catch {
+      return page.url ?? "/";
+    }
+  }, [page.url]);
+
+  return (
+    // z-index above Radix's portalled overlays (they land on document.body at
+    // the shell's own stacking level), so the bar is never buried under a Sheet
+    // the bench itself asked the page to open.
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-[2147483000] flex flex-col items-stretch font-sans">
+      {state.open && (
+        <section className="pointer-events-auto mx-auto mb-1 flex h-[min(60vh,32rem)] w-full max-w-3xl flex-col overflow-hidden rounded-t-lg border border-neutral-800 bg-neutral-900/95 backdrop-blur">
+          <nav className="flex shrink-0 gap-1 border-b border-neutral-800 px-2 py-1.5">
+            {PANELS.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => patch({ panel: p.id })}
+                className={
+                  "rounded px-2 py-1 text-xs " +
+                  (state.panel === p.id
+                    ? "bg-neutral-700 text-neutral-50"
+                    : "text-neutral-400 hover:bg-neutral-800")
+                }
+              >
+                {p.label}
+              </button>
+            ))}
+          </nav>
+
+          <div className="min-h-0 flex-1 overflow-auto p-2">
+            {state.panel === "pages" && <PagesPanel pages={manifest.pages} current={page.component ?? ""} />}
+            {state.panel === "routes" && <RoutesPanel routes={manifest.routes} current={path} />}
+            {state.panel === "inspect" && <InspectPanel page={page} />}
+            {state.panel === "shell" && <ShellPanel shell={state.shell} onChange={(next) => patch({ shell: next })} />}
+          </div>
+        </section>
+      )}
+
+      <div className="pointer-events-auto flex items-center gap-3 border-t border-neutral-800 bg-neutral-900/95 px-3 py-1.5 text-xs text-neutral-400 backdrop-blur">
+        <button
+          type="button"
+          onClick={() => patch({ open: !state.open })}
+          title={state.open ? "Collapse the bench" : "Open the bench"}
+          className="rounded px-1.5 py-0.5 font-medium text-neutral-200 hover:bg-neutral-800"
+        >
+          {state.open ? "▾" : "▴"} ground
+        </button>
+
+        <span className="truncate text-neutral-500" title={`${manifest.name} — ${manifest.solves}`}>
+          {manifest.name}
+        </span>
+
+        <span className="ml-auto flex items-center gap-1">
+          <Group>
+            {LAYOUTS.map((l) => (
+              <Toggle
+                key={l.id}
+                active={state.layout === l.id}
+                title={l.title}
+                onClick={() => patch({ layout: l.id })}
+                // A forced layout is not the default and must not look like it.
+                tone={state.layout === l.id && l.id !== "page" ? "warn" : "normal"}
+              >
+                {l.label}
+              </Toggle>
+            ))}
+          </Group>
+
+          <Group>
+            {VIEWPORTS.map((v) => (
+              <Toggle
+                key={v.id}
+                active={state.viewport === v.id}
+                title={v.title}
+                onClick={() => patch({ viewport: v.id })}
+                tone={state.viewport === v.id && v.id !== "full" ? "warn" : "normal"}
+              >
+                {v.label}
+              </Toggle>
+            ))}
+          </Group>
+
+          {state.shell !== null && (
+            <span
+              title="adminShell is being faked by the bench — the server is not sending this."
+              className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-300"
+            >
+              shell faked
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function Group({ children }: { children: ReactNode }) {
+  return <span className="flex overflow-hidden rounded border border-neutral-700">{children}</span>;
+}
+
+function Toggle({
+  active,
+  tone,
+  title,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  tone: "normal" | "warn";
+  title: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      className={
+        "px-1.5 py-0.5 text-[11px] " +
+        (active
+          ? tone === "warn"
+            ? "bg-amber-500/20 text-amber-200"
+            : "bg-neutral-700 text-neutral-100"
+          : "text-neutral-400 hover:bg-neutral-800")
+      }
+    >
+      {children}
+    </button>
+  );
+}

--- a/modules/ground/ui/dev/index.ts
+++ b/modules/ground/ui/dev/index.ts
@@ -1,0 +1,3 @@
+export { GroundFrame } from "./GroundFrame";
+export type { GroundFrameProps } from "./GroundFrame";
+export type { GroundManifest, GroundPage, GroundRoute } from "./types";

--- a/modules/ground/ui/dev/panels.tsx
+++ b/modules/ground/ui/dev/panels.tsx
@@ -1,0 +1,366 @@
+import { useMemo, useState } from "react";
+import { router } from "@pageflow/react";
+import { getAllFeatures } from "@pageflow/admin";
+import type { GroundManifest, GroundPage, GroundRoute } from "./types";
+import type { GroundState } from "./state";
+
+// ── Shared bits ───────────────────────────────────────────────────────────────
+
+function Search({ value, onChange, placeholder }: { value: string; onChange: (v: string) => void; placeholder: string }) {
+  return (
+    <input
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      className="mb-2 w-full rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-xs text-neutral-100 placeholder:text-neutral-500 focus:border-neutral-500 focus:outline-none"
+    />
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return <p className="px-1 py-6 text-center text-xs text-neutral-500">{children}</p>;
+}
+
+const METHOD_TONE: Record<string, string> = {
+  GET: "text-emerald-400",
+  POST: "text-sky-400",
+  PUT: "text-amber-400",
+  PATCH: "text-amber-400",
+  DELETE: "text-rose-400",
+};
+
+// ── Pages ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Every page the plugin ships, whether or not a route reaches it.
+ *
+ * That last part is the reason this exists. A page with no route is
+ * unreachable in a browser — there is no URL to type — so the only way to look
+ * at one was to add a throwaway route to module.json. Here it is one click,
+ * because Pageflow can be told to swap the component directly.
+ */
+export function PagesPanel({ pages, current }: { pages: GroundPage[]; current: string }) {
+  const [query, setQuery] = useState("");
+
+  const shown = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return needle === "" ? pages : pages.filter((p) => p.component.toLowerCase().includes(needle));
+  }, [pages, query]);
+
+  if (pages.length === 0) {
+    return <Empty>This plugin ships no pages under admin/Pages or site/Pages.</Empty>;
+  }
+
+  return (
+    <div>
+      <Search value={query} onChange={setQuery} placeholder="Filter pages…" />
+      <ul className="space-y-0.5">
+        {shown.map((page) => {
+          const active = page.component === current;
+
+          return (
+            <li key={page.face + "/" + page.component}>
+              <button
+                type="button"
+                disabled={page.path === null}
+                title={page.path ?? "No route renders this page — nothing to visit."}
+                onClick={() => page.path !== null && router.visit(page.path)}
+                className={
+                  "flex w-full items-center justify-between gap-2 rounded px-2 py-1 text-left text-xs " +
+                  (active
+                    ? "bg-neutral-700 text-neutral-50"
+                    : page.path === null
+                      ? "cursor-not-allowed text-neutral-600"
+                      : "text-neutral-300 hover:bg-neutral-800")
+                }
+              >
+                <span className="truncate">{page.component}</span>
+                <span className="shrink-0 text-[10px] uppercase tracking-wide text-neutral-500">
+                  {page.path === null ? "no route" : page.face}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+        {shown.length === 0 && <Empty>No page matches “{query}”.</Empty>}
+      </ul>
+    </div>
+  );
+}
+
+// ── Routes ────────────────────────────────────────────────────────────────────
+
+/**
+ * The plugin's routes, with every group and module prefix already applied.
+ *
+ * A dynamic path is listed but not clickable: `/users/{id:num}` is not a URL,
+ * and a bench that navigated to the literal string would 404 and look like the
+ * route was broken.
+ */
+export function RoutesPanel({ routes, current }: { routes: GroundRoute[]; current: string }) {
+  const [query, setQuery] = useState("");
+
+  const shown = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return needle === ""
+      ? routes
+      : routes.filter((r) => (r.path + " " + r.method + " " + (r.name ?? "")).toLowerCase().includes(needle));
+  }, [routes, query]);
+
+  if (routes.length === 0) return <Empty>module.json declares no routes.</Empty>;
+
+  return (
+    <div>
+      <Search value={query} onChange={setQuery} placeholder="Filter routes…" />
+      <ul className="space-y-0.5">
+        {shown.map((route) => {
+          const visitable = !route.dynamic && route.method === "GET";
+
+          return (
+            <li key={route.method + " " + route.path}>
+              <button
+                type="button"
+                disabled={!visitable}
+                title={
+                  route.dynamic
+                    ? "Takes a parameter — not a URL that can be visited as written."
+                    : route.method !== "GET"
+                      ? `${route.method} — the bench only navigates with GET.`
+                      : route.path
+                }
+                onClick={() => visitable && router.visit(route.path)}
+                className={
+                  "w-full rounded px-2 py-1 text-left text-xs " +
+                  (route.path === current
+                    ? "bg-neutral-700"
+                    : visitable
+                      ? "hover:bg-neutral-800"
+                      : "cursor-not-allowed opacity-60")
+                }
+              >
+                <span className="flex items-baseline gap-2">
+                  <span className={"shrink-0 font-mono text-[10px] " + (METHOD_TONE[route.method] ?? "text-neutral-400")}>
+                    {route.method}
+                  </span>
+                  <span className="truncate text-neutral-300">{route.path}</span>
+                </span>
+                {(route.filters.length > 0 || route.requires.length > 0) && (
+                  <span className="mt-0.5 flex flex-wrap gap-1">
+                    {route.filters.map((f) => (
+                      <span key={f} className="rounded bg-neutral-800 px-1 text-[10px] text-neutral-400">
+                        {f}
+                      </span>
+                    ))}
+                    {route.requires.map((r) => (
+                      <span key={r} className="rounded bg-neutral-800 px-1 text-[10px] text-sky-300/70">
+                        {r}
+                      </span>
+                    ))}
+                  </span>
+                )}
+              </button>
+            </li>
+          );
+        })}
+        {shown.length === 0 && <Empty>No route matches “{query}”.</Empty>}
+      </ul>
+    </div>
+  );
+}
+
+// ── The page object ───────────────────────────────────────────────────────────
+
+/**
+ * `{component, url, props}` — the server's actual contract with the client.
+ *
+ * Ground's whole testing doctrine is to assert on the page object and never on
+ * markup, because the markup belongs to a component a designer may rewrite this
+ * afternoon while the props are the thing the server promised. Showing it here
+ * is that doctrine made visible: the prop you cannot find in this tree is the
+ * one the page is about to render as `undefined`.
+ */
+export function InspectPanel({ page }: { page: { component?: string; url?: string; props?: unknown } }) {
+  const props = (page.props ?? {}) as Record<string, unknown>;
+  const names = Object.keys(props);
+
+  return (
+    <div className="space-y-3 text-xs">
+      <dl className="space-y-1">
+        <Row label="component" value={page.component ?? "—"} />
+        <Row label="url" value={page.url ?? "—"} />
+        <Row label="props" value={names.length === 0 ? "(none)" : `${names.length} key(s)`} />
+      </dl>
+
+      {names.map((name) => (
+        <PropNode key={name} name={name} value={props[name]} />
+      ))}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-2">
+      <dt className="w-20 shrink-0 text-neutral-500">{label}</dt>
+      <dd className="truncate font-mono text-neutral-200" title={value}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+/** One prop, collapsed. Objects and arrays open on demand rather than by default:
+ *  a page with a 200-row table would otherwise fill the panel with its own data. */
+function PropNode({ name, value }: { name: string; value: unknown }) {
+  const [open, setOpen] = useState(false);
+  const complex = value !== null && typeof value === "object";
+
+  const summary = complex
+    ? Array.isArray(value)
+      ? `Array(${value.length})`
+      : `{${Object.keys(value as object).length}}`
+    : JSON.stringify(value);
+
+  return (
+    <div className="rounded border border-neutral-800">
+      <button
+        type="button"
+        onClick={() => complex && setOpen((o) => !o)}
+        className="flex w-full items-baseline justify-between gap-2 px-2 py-1 text-left hover:bg-neutral-800/60"
+      >
+        <span className="truncate font-mono text-neutral-300">{name}</span>
+        <span className="shrink-0 font-mono text-[10px] text-neutral-500">
+          {complex ? (open ? "▾ " : "▸ ") : ""}
+          {summary}
+        </span>
+      </button>
+      {open && complex && (
+        <pre className="max-h-64 overflow-auto border-t border-neutral-800 px-2 py-1 font-mono text-[10px] leading-relaxed text-neutral-400">
+          {safeStringify(value)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+/** Props reach here straight off the wire, so a cycle is not impossible and a
+ *  throw inside the inspector would take down the page it is inspecting. */
+function safeStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  try {
+    return JSON.stringify(
+      value,
+      (_key, val) => {
+        if (val !== null && typeof val === "object") {
+          if (seen.has(val)) return "[circular]";
+          seen.add(val);
+        }
+        return val;
+      },
+      2,
+    );
+  } catch (error) {
+    return `[not serialisable: ${(error as Error).message}]`;
+  }
+}
+
+// ── adminShell ────────────────────────────────────────────────────────────────
+
+/**
+ * Fake the `adminShell` shared prop the server does not send yet.
+ *
+ * No PHP anywhere writes `adminShell`, so `useAdminShell()` returns a guest with
+ * no features, `selectNavSections([])` returns nothing, and the sidebar renders
+ * permanently empty. That is not a bug you can see by looking harder — there is
+ * no state of the application in which it fills up.
+ *
+ * So the bench supplies one. The overrides are merged over the server's value
+ * (which stays authoritative when it exists) and only for this browser, so
+ * nothing here can be mistaken for the server having been fixed.
+ */
+export function ShellPanel({
+  shell,
+  onChange,
+}: {
+  shell: GroundState["shell"];
+  onChange: (next: GroundState["shell"]) => void;
+}) {
+  // getModules() filters by the ENABLED set, so with nothing enabled it returns
+  // empty even when every module registered correctly — it would report "none
+  // registered" for the exact state this panel exists to fix. The feature
+  // registry is the honest signal: it is populated at import time and does not
+  // depend on what is switched on.
+  const features = getAllFeatures();
+  const active = (shell?.features as string[] | undefined) ?? [];
+
+  const set = (patch: Record<string, unknown>) => onChange({ ...(shell ?? {}), ...patch });
+
+  const toggle = (id: string) =>
+    set({ features: active.includes(id) ? active.filter((f) => f !== id) : [...active, id] });
+
+  return (
+    <div className="space-y-3 text-xs">
+      <Field
+        label="displayName"
+        value={((shell?.user as { displayName?: string } | undefined)?.displayName) ?? ""}
+        onChange={(v) => set({ user: { ...(shell?.user ?? { id: "ground" }), displayName: v } })}
+      />
+      <Field
+        label="tenant"
+        value={((shell?.tenant as { name?: string } | undefined)?.name) ?? ""}
+        onChange={(v) => set({ tenant: v === "" ? null : { id: "ground", name: v } })}
+      />
+
+      <div>
+        <p className="mb-1 text-neutral-500">features</p>
+        {features.length === 0 ? (
+          <p className="text-neutral-500">
+            No nav module is registered. A plugin contributes one from{" "}
+            <code className="text-neutral-400">ui/admin/nav.ts</code>; the bench imports that file
+            if it exists.
+          </p>
+        ) : (
+          <ul className="space-y-0.5">
+            {features.map((feature) => (
+              <li key={feature.id}>
+                <label className="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 hover:bg-neutral-800">
+                  <input
+                    type="checkbox"
+                    checked={active.includes(feature.id)}
+                    onChange={() => toggle(feature.id)}
+                    className="accent-emerald-500"
+                  />
+                  <span className="truncate text-neutral-300">{feature.label ?? feature.id}</span>
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {shell !== null && (
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          className="w-full rounded border border-neutral-700 px-2 py-1 text-neutral-400 hover:bg-neutral-800"
+        >
+          Clear overrides — use what the server sent
+        </button>
+      )}
+    </div>
+  );
+}
+
+function Field({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-neutral-500">{label}</span>
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded border border-neutral-700 bg-neutral-900 px-2 py-1 text-neutral-100 focus:border-neutral-500 focus:outline-none"
+      />
+    </label>
+  );
+}

--- a/modules/ground/ui/dev/state.ts
+++ b/modules/ground/ui/dev/state.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type LayoutChoice = "page" | "bare" | "admin" | "auth";
+export type ViewportChoice = "full" | "tablet" | "mobile";
+export type PanelChoice = "pages" | "routes" | "inspect" | "shell";
+
+export interface GroundState {
+  /** Is the side panel open, or is the bench collapsed to its bar? */
+  open: boolean;
+  panel: PanelChoice;
+  /**
+   * Which layout to wrap the page in.
+   *
+   * "page" is the default and the only one that is not a lie: it honours the
+   * page's own `.layout` and falls back to the admin shell exactly as the
+   * generated entry does, so what you see is what a project renders. The other
+   * three FORCE a layout, which is useful for comparing and misleading if you
+   * forget it is set — hence the bar showing it at all times.
+   */
+  layout: LayoutChoice;
+  viewport: ViewportChoice;
+  /** Overrides merged over the server's `adminShell` prop. */
+  shell: Record<string, unknown> | null;
+}
+
+const KEY = "__ground_bench__";
+
+const DEFAULTS: GroundState = {
+  open: false,
+  panel: "pages",
+  layout: "page",
+  viewport: "full",
+  shell: null,
+};
+
+/**
+ * Bench state, persisted per browser.
+ *
+ * localStorage rather than a URL parameter on purpose: these are preferences
+ * about the BENCH, and putting them in the URL would change the address you
+ * copy out of the bar to share or to curl — which is one of the things the
+ * route list is for.
+ *
+ * Every read and write is guarded. jsdom under vitest, a private window, and a
+ * browser set to block site data all produce a localStorage that is absent or
+ * that throws on access, and a dev tool that takes the page down in those is
+ * worse than one that forgets its panel was open.
+ */
+export function useGroundState(): [GroundState, (patch: Partial<GroundState>) => void] {
+  const [state, setState] = useState<GroundState>(() => {
+    try {
+      const raw = window.localStorage.getItem(KEY);
+      return raw ? { ...DEFAULTS, ...(JSON.parse(raw) as Partial<GroundState>) } : DEFAULTS;
+    } catch {
+      return DEFAULTS;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(KEY, JSON.stringify(state));
+    } catch {
+      /* not persisting is not a reason to fail the page */
+    }
+  }, [state]);
+
+  const patch = useCallback(
+    (next: Partial<GroundState>) => setState((current) => ({ ...current, ...next })),
+    [],
+  );
+
+  return [state, patch];
+}

--- a/modules/ground/ui/dev/types.ts
+++ b/modules/ground/ui/dev/types.ts
@@ -1,0 +1,49 @@
+/**
+ * What the bench knows about the plugin it is showing.
+ *
+ * Generated into `ui/.ground/src/ground.manifest.ts` by DevWorkspace, from the
+ * plugin's own module.json and ui.json — so it is regenerated on every
+ * `ground dev` and cannot describe a plugin that has since changed.
+ *
+ * It is deliberately STATIC. Anything that varies per request (what the fake
+ * database was asked, what mail went nowhere, which events fired) is absent,
+ * because `ground serve` boots fresh for every request and that data would be
+ * a request out of date before it was read.
+ */
+export interface GroundManifest {
+  /** The plugin's `name` from module.json. */
+  name: string;
+  /** Its `solves` domain. */
+  solves: string;
+  /** Module domains it declares a dependency on. */
+  requires: string[];
+  /** Contracts it publishes. */
+  exposes: string[];
+  /** Integration events it says it emits. */
+  emits: string[];
+  /** Surface name → the pages directory it globs, from ui.json. */
+  surfaces: Record<string, string>;
+  pages: GroundPage[];
+  routes: GroundRoute[];
+}
+
+export interface GroundPage {
+  /** The Pageflow component name, e.g. "User/Index". */
+  component: string;
+  /** Which face it was authored under: "admin" or "site". */
+  face: string;
+  /** The route path that renders it, when one could be matched. */
+  path: string | null;
+}
+
+export interface GroundRoute {
+  method: string;
+  /** The FULL path, with every group and module prefix already applied. */
+  path: string;
+  handler: string;
+  name: string | null;
+  filters: string[];
+  requires: string[];
+  /** True when the path takes a {parameter} and cannot be visited as written. */
+  dynamic: boolean;
+}

--- a/modules/ground/ui/dev/viewport.ts
+++ b/modules/ground/ui/dev/viewport.ts
@@ -1,0 +1,167 @@
+import type { ViewportChoice } from "./state";
+
+/** Simulated widths, in CSS pixels. `full` means "use the real window". */
+export const VIEWPORT_WIDTH: Record<ViewportChoice, number | null> = {
+  full: null,
+  tablet: 834,
+  mobile: 390,
+};
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+interface Tracked {
+  query: string;
+  listeners: Set<Listener>;
+  last: boolean;
+}
+
+let native: typeof window.matchMedia | null = null;
+let simulated: number | null = null;
+
+const tracked = new Set<Tracked>();
+
+/**
+ * Answer a width query against a simulated width.
+ *
+ * Only `min-width` / `max-width` in px are understood. Everything else —
+ * `prefers-reduced-motion`, `orientation`, `hover`, `prefers-color-scheme` — is
+ * returned as null so the caller delegates to the browser: a simulated WIDTH
+ * says nothing about any of them, and answering anyway would be inventing a
+ * result.
+ */
+function evaluate(query: string, width: number): boolean | null {
+  const clauses = query.split(/\s+and\s+/i).map((clause) => clause.trim());
+  let result = true;
+
+  for (const clause of clauses) {
+    const match = /^\(\s*(min|max)-width\s*:\s*(\d+(?:\.\d+)?)px\s*\)$/i.exec(clause);
+
+    if (match === null) {
+      return null;
+    }
+
+    result = result && (match[1].toLowerCase() === "min" ? width >= Number(match[2]) : width <= Number(match[2]));
+  }
+
+  return clauses.length > 0 ? result : null;
+}
+
+/** Is this a query the simulation is entitled to answer? */
+function isWidthQuery(query: string): boolean {
+  return evaluate(query, 0) !== null;
+}
+
+function currentlyMatches(query: string): boolean {
+  return simulated === null
+    ? (native?.(query).matches ?? false)
+    : (evaluate(query, simulated) ?? false);
+}
+
+/**
+ * Route `window.matchMedia` through the bench for the lifetime of the frame.
+ *
+ * ─── WHY IT INSTALLS EAGERLY, BEFORE ANY SIMULATION ─────────────────────────
+ *
+ * Installing only when a viewport is picked does not work, and fails in a way
+ * that looks like the control is broken rather than absent: the shell has
+ * already mounted and already called `window.matchMedia`, so its `change`
+ * listener sits on the list the NATIVE function returned. Nothing the shim does
+ * afterwards can reach that listener, so `matches` flips, the bench reports a
+ * phone, and the desktop sidebar stays exactly where it was.
+ *
+ * So the shim is installed AT IMPORT and simply tells the truth until asked not
+ * to — every subscription goes through it from the first render, and switching
+ * viewport notifies the components that are actually listening.
+ *
+ * Import time, not a mount effect, because React runs effects BOTTOM-UP: the
+ * shell is a child of the frame, so `useMediaQuery`'s effect subscribes before
+ * any effect the frame could install from. Only a side effect at module load is
+ * reliably ahead of the first render — and this module is reached through the
+ * frame, which the generated entry imports before it mounts anything.
+ *
+ * ─── WHY IT IS A GLOBAL MUTATION AT ALL ─────────────────────────────────────
+ *
+ * `useIsMobile` is `matchMedia("(max-width: 767px)")`, which reports the WINDOW.
+ * Constraining a wrapper element to 390px therefore proves nothing: the shell
+ * keeps rendering its desktop rail inside a phone-width box, and the mobile
+ * drawer — a whole branch of AdminLayout with its own Sheet and its own
+ * overflow behaviour — stays unreachable. That branch is the entire reason a
+ * viewport control exists, so the window is what has to lie.
+ */
+export function installViewportShim(): () => void {
+  if (typeof window === "undefined" || native !== null) {
+    return uninstall;
+  }
+
+  native = window.matchMedia.bind(window);
+
+  window.matchMedia = ((query: string) => {
+    if (!isWidthQuery(query)) {
+      return native!(query);
+    }
+
+    const entry: Tracked = { query, listeners: new Set(), last: currentlyMatches(query) };
+    tracked.add(entry);
+
+    return {
+      get matches() {
+        return currentlyMatches(query);
+      },
+      media: query,
+      onchange: null,
+      addEventListener: (_type: string, listener: Listener) => void entry.listeners.add(listener),
+      removeEventListener: (_type: string, listener: Listener) => {
+        entry.listeners.delete(listener);
+        if (entry.listeners.size === 0) tracked.delete(entry);
+      },
+      // Deprecated, and still what some libraries reach for first.
+      addListener: (listener: Listener) => void entry.listeners.add(listener),
+      removeListener: (listener: Listener) => void entry.listeners.delete(listener),
+      dispatchEvent: () => false,
+    } as unknown as MediaQueryList;
+  }) as typeof window.matchMedia;
+
+  return uninstall;
+}
+
+/** Restore the browser's own matchMedia. Exported for tests; the bench itself
+ *  keeps the shim for the life of the document. */
+export function uninstall(): void {
+  simulated = null;
+
+  // Tell every subscriber the truth BEFORE handing the native function back:
+  // one that unsubscribes after the restore would otherwise keep the last
+  // simulated answer until something unrelated made it re-render.
+  notify();
+
+  if (native !== null) {
+    window.matchMedia = native;
+  }
+
+  native = null;
+  tracked.clear();
+}
+
+// Installed on import — see installViewportShim() for why an effect is too late.
+installViewportShim();
+
+export function setSimulatedWidth(width: number | null): void {
+  if (simulated === width) return;
+
+  simulated = width;
+  notify();
+}
+
+function notify(): void {
+  for (const entry of tracked) {
+    const now = currentlyMatches(entry.query);
+
+    if (now === entry.last) continue;
+
+    entry.last = now;
+
+    for (const listener of [...entry.listeners]) {
+      listener({ matches: now, media: entry.query } as MediaQueryListEvent);
+    }
+  }
+}

--- a/modules/ground/ui/ui.json
+++ b/modules/ground/ui/ui.json
@@ -1,0 +1,10 @@
+{
+  "alias": "@ground",
+  "entry": "dev/index.ts",
+  "framework": "react",
+  "exports": {
+    "@ground/dev": "dev/index.ts"
+  },
+  "surfaces": {},
+  "dependencies": {}
+}

--- a/templates/frontend/src/shared/providers/theme.tsx
+++ b/templates/frontend/src/shared/providers/theme.tsx
@@ -1,22 +1,136 @@
 import * as React from "react";
 
-type Theme = "light" | "dark";
-const ThemeContext = React.createContext<{ theme: Theme; toggle: () => void }>({
-  theme: "light",
+/**
+ * What the user CHOSE. `system` defers to the OS, and is a real third state —
+ * not a synonym for whichever of the two the OS currently reports, because a
+ * choice of `system` has to keep tracking the OS when it changes.
+ */
+export type Theme = "light" | "dark" | "system";
+
+/** What is actually on screen. Never `system`. */
+export type ResolvedTheme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+  /** Flip light↔dark. From `system`, flips away from whatever the OS resolves to. */
+  toggle: () => void;
+}
+
+const STORAGE_KEY = "theme";
+const QUERY = "(prefers-color-scheme: dark)";
+
+const ThemeContext = React.createContext<ThemeContextValue>({
+  theme: "system",
+  resolvedTheme: "light",
+  setTheme: () => {},
   toggle: () => {},
 });
 
-/** Minimal light/dark provider — swap for your real one as the app grows. */
+/**
+ * Light / dark / system, applied by toggling `.dark` on the document element.
+ *
+ * ─── WHY THIS IS NOT THE TWO-STATE VERSION IT USED TO BE ────────────────────
+ *
+ * It exposed `{ theme, toggle }` with `theme: "light" | "dark"`, and both of its
+ * consumers were already written against a THREE-state API:
+ *
+ *   @pageflow/admin's ThemeToggle destructures `setTheme` and calls it with
+ *   "light" | "dark" | "system" — so every click called `undefined`, and the
+ *   theme switch in the admin sidebar did nothing at all;
+ *
+ *   the shared sonner.tsx does `const { theme = 'system' } = useTheme()` and
+ *   passes it straight to <Sonner theme={…}>, which understands all three.
+ *
+ * Neither failure is visible to a type-check or a build: the toggle throws only
+ * when a menu item is clicked, and sonner's default silently never applied
+ * because `theme` was always defined.
+ *
+ * `toggle()` is kept because it is a reasonable thing to want and removing it
+ * would be a breaking change for anything outside this repo.
+ */
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = React.useState<Theme>(
-    () => (localStorage.getItem("theme") as Theme) || "light",
-  );
+  const [theme, setThemeState] = React.useState<Theme>(() => read());
+  const [systemDark, setSystemDark] = React.useState<boolean>(() => prefersDark());
+
+  // A `system` choice must keep tracking the OS, so this subscribes for the
+  // life of the provider rather than only while `system` is selected —
+  // subscribing conditionally would mean the first change after switching away
+  // and back is missed.
   React.useEffect(() => {
-    document.documentElement.classList.toggle("dark", theme === "dark");
-    localStorage.setItem("theme", theme);
-  }, [theme]);
-  const toggle = () => setTheme((t) => (t === "light" ? "dark" : "light"));
-  return <ThemeContext.Provider value={{ theme, toggle }}>{children}</ThemeContext.Provider>;
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const list = window.matchMedia(QUERY);
+    const onChange = (event: MediaQueryListEvent) => setSystemDark(event.matches);
+
+    setSystemDark(list.matches);
+    list.addEventListener("change", onChange);
+
+    return () => list.removeEventListener("change", onChange);
+  }, []);
+
+  const resolvedTheme: ResolvedTheme =
+    theme === "system" ? (systemDark ? "dark" : "light") : theme;
+
+  React.useEffect(() => {
+    document.documentElement.classList.toggle("dark", resolvedTheme === "dark");
+    // Lets CSS and the browser's own form controls follow the theme.
+    document.documentElement.style.colorScheme = resolvedTheme;
+  }, [resolvedTheme]);
+
+  const setTheme = React.useCallback((next: Theme) => {
+    setThemeState(next);
+    write(next);
+  }, []);
+
+  const toggle = React.useCallback(
+    () => setTheme(resolvedTheme === "dark" ? "light" : "dark"),
+    [resolvedTheme, setTheme],
+  );
+
+  const value = React.useMemo(
+    () => ({ theme, resolvedTheme, setTheme, toggle }),
+    [theme, resolvedTheme, setTheme, toggle],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
 export const useTheme = () => React.useContext(ThemeContext);
+
+/**
+ * Storage access is guarded in both directions.
+ *
+ * A private window, a browser set to block site data, and Node 24+ without
+ * --localstorage-file all produce a `localStorage` that is missing or that
+ * THROWS on access. Reading it unguarded — as this did — takes the whole app
+ * down before first paint, for a remembered preference.
+ */
+function read(): Theme {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+
+    return stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
+  } catch {
+    return "system";
+  }
+}
+
+function write(theme: Theme): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    /* not remembering the choice is not a reason to fail the page */
+  }
+}
+
+function prefersDark(): boolean {
+  try {
+    return window.matchMedia(QUERY).matches;
+  } catch {
+    return false;
+  }
+}

--- a/templates/frontend/src/shared/styles/theme.css
+++ b/templates/frontend/src/shared/styles/theme.css
@@ -7,6 +7,12 @@
  * @ui/* can use `bg-background`, `text-muted-foreground`, `border-border`,
  * `ring-ring`, `rounded-lg`, etc. `tw-animate-css` supplies the `animate-in` /
  * `data-[state=open]` transitions shadcn components rely on.
+ *
+ * It also carries the `--sidebar-*` chrome tokens that @pageflow/admin's shell
+ * reads. Those referenced nothing for a while: the shell was ported out of HKM
+ * 0.3 and its stylesheet was left behind, so every class it names
+ * (`bg-sidebar-bg`, `text-sidebar-fg-muted`, `w-[var(--sidebar-width)]`)
+ * resolved to no colour and no width in every project.
  */
 @import "tailwindcss";
 @import "tw-animate-css";
@@ -40,6 +46,31 @@
   --chart-3: 197 37% 24%;
   --chart-4: 43 74% 66%;
   --chart-5: 27 87% 67%;
+
+  /*
+   * Admin sidebar chrome, consumed by @pageflow/admin's shell (AdminLayout,
+   * Sidebar, SidebarNav, OrgSwitcher). They live HERE, beside the shadcn
+   * tokens, because the shell references them from every surface — a project's
+   * and the one `ground dev` generates alike — and a token defined in only one
+   * of those renders the sidebar transparent in the other.
+   *
+   * The two accent tokens defer to --primary rather than restating a colour, so
+   * a project that rebrands by overriding --primary gets a matching sidebar and
+   * never discovers this block. The neutrals are their own values: a sidebar
+   * that tracked --background would vanish against the page it sits next to.
+   */
+  --sidebar-bg: 0 0% 100%;
+  --sidebar-fg: 0 0% 30%;
+  --sidebar-fg-muted: 0 0% 55%;
+  --sidebar-fg-active: var(--primary);
+  --sidebar-border: 214.3 31.8% 91.4%;
+  --sidebar-hover: 210 40% 96%;
+  --sidebar-active: var(--primary);
+  --sidebar-section: 0 0% 45%;
+
+  /* A LENGTH, not a colour — read directly as var() by the layout's motion
+     variants and `w-[var(--sidebar-width)]`, so it is not in @theme inline. */
+  --sidebar-width: 260px;
 }
 
 .dark {
@@ -67,6 +98,15 @@
   --chart-3: 30 80% 55%;
   --chart-4: 280 65% 60%;
   --chart-5: 340 75% 55%;
+
+  --sidebar-bg: 222.2 84% 4.9%;
+  --sidebar-fg: 210 40% 80%;
+  --sidebar-fg-muted: 215 20.2% 55%;
+  --sidebar-fg-active: var(--primary);
+  --sidebar-border: 217.2 32.6% 17.5%;
+  --sidebar-hover: 217.2 32.6% 17.5%;
+  --sidebar-active: var(--primary);
+  --sidebar-section: 215 20.2% 55%;
 }
 
 /* Map the HSL tokens onto Tailwind's color/radius scales (v4 `@theme inline`). */
@@ -96,6 +136,15 @@
   --color-chart-4: hsl(var(--chart-4));
   --color-chart-5: hsl(var(--chart-5));
 
+  --color-sidebar-bg: hsl(var(--sidebar-bg));
+  --color-sidebar-fg: hsl(var(--sidebar-fg));
+  --color-sidebar-fg-muted: hsl(var(--sidebar-fg-muted));
+  --color-sidebar-fg-active: hsl(var(--sidebar-fg-active));
+  --color-sidebar-border: hsl(var(--sidebar-border));
+  --color-sidebar-hover: hsl(var(--sidebar-hover));
+  --color-sidebar-active: hsl(var(--sidebar-active));
+  --color-sidebar-section: hsl(var(--sidebar-section));
+
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -110,4 +159,13 @@
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
   }
+}
+
+/*
+ * The shell's own transition utility, used on every sidebar row and toggle.
+ * Declared as @utility (not a plain class) so Tailwind orders it with the rest
+ * of the utility layer and a `hover:` variant on the same element still wins.
+ */
+@utility sidebar-transition {
+  transition: all 200ms ease-out;
 }


### PR DESCRIPTION
Releases **v1.10.0**. Merging this pushes the tag and runs the build — the
CHANGELOG heading is already promoted.

## Why

`ground dev` could not show a plugin's UI reliably. Three separate reasons, each
of which failed silently:

- the generated entry handed Pageflow's `<App>` no `children`, so a page with no
  `.layout` rendered bare — three of the eight plugin admin pages on disk;
- it loaded **no CSS at all** (no Tailwind plugin, no stylesheet import) while
  the pages, the `@ui` kit and the admin shell are Tailwind-only;
- it marked only **one** surface hot, so a plugin whose pages render on `site`
  got no `<script>` tags and served a shell with an empty `#app`.

## What changed

**A dev bench, not a replacement layout.** `GroundFrame` (`@ground/dev`, new,
in this package's own `ui/`) is chrome *around* the page — the production tree
renders untouched inside it, because `ground serve` running the real pipeline is
the only reason to trust what it shows. It makes the layout a control (`page` /
`bare` / `admin` / `auth`) and surfaces what only ground knows: every page from
the glob with the route that renders it, the plugin's routes with prefixes and
filters resolved, the page object, and an `adminShell` seeder.

**Two hot-file bugs.** Every declared surface is now marked hot by the one
server; and a dev server that fails to bind no longer deletes a *running* one's
hot file — ownership is claimed inside the `listening` handler rather than in
`configureServer`, which runs before the port is bound.

**`ThemeProvider` did not implement the API its consumers call.** It exposed
`{ theme, toggle }`; `@pageflow/admin`'s `ThemeToggle` destructures `setTheme`
and calls it with `"light" | "dark" | "system"`, so every click on the admin
theme switch called `undefined`. `sonner.tsx` already defaulted `theme` to
`'system'`. Neither is visible to a type-check or a build.

**The eleven `--sidebar-*` tokens** the admin shell names were defined nowhere —
the shell was ported out of HKM 0.3 and its stylesheet left behind, so the
sidebar was transparent with no width in every project. An undefined custom
property is not an error, so nothing reported it.

## Verified

- ground **186/186**, kernel **389/389**
- a real Vite build of the generated workspace: 77KB of CSS with
  `bg-sidebar-bg{background-color:hsl(var(--sidebar-bg))}` and
  `--sidebar-width:260px` actually emitted
- the real generated entry booted from a captured server payload renders a
  layout-less page inside the shell
- the theme switch driven against the real `ThemeToggle`: choosing Dark puts
  `.dark` on the document, persists, and `system` resolves and tracks the OS
- the hot-file regression reproduced and then confirmed fixed

## Note

`## [Unreleased]` was empty, so this release is exactly this branch.
