### PR TITLE
release: v1.10.1 — ground init generates a workflow that calls a real binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-09-01
+
+### Fixed
+- **`hkm ground init` generated a CI workflow that called a binary nothing
+  installs.** The generated `.github/workflows/ground.yml` ran
+  `vendor/bin/hkm-ground check --here` and `vendor/bin/hkm-ground migrate
+  --strict`, but this package declares `"bin": ["bin/hkm-cli",
+  "modules/ground/bin/ground"]` — so what a plugin actually gets in its
+  `vendor/bin` is `ground`. No package has ever shipped a `hkm-ground`
+  executable, and `alfacode-team/ground` is not published separately at all: it
+  is a path repo inside this repository, reachable only because the kernel
+  autoloads it.
+
+  So every plugin that ran `ground init` got a workflow whose first step could
+  only ever exit 127, `No such file or directory` — and it failed at the step
+  AFTER `composer install` succeeded, which reads like the plugin is broken
+  rather than like the workflow named the wrong file. Five plugin repositories
+  had already been scaffolded with it.
+
+  The generator now emits `vendor/bin/ground`. Existing checkouts need the two
+  lines changed by hand or `ground init` re-run; nothing else in the workflow
+  moves.
+
 ## [1.10.0] - 2026-09-01
 
 ### Added

--- a/modules/ground/src/Init.php
+++ b/modules/ground/src/Init.php
@@ -213,13 +213,13 @@ final class Init
               - run: composer install --no-interaction --prefer-dist
 
               - name: Static checks
-                run: vendor/bin/hkm-ground check --here
+                run: vendor/bin/ground check --here
 
               - name: Tests
                 run: vendor/bin/phpunit
 
               - name: Migrations, on every database
-                run: vendor/bin/hkm-ground migrate --strict
+                run: vendor/bin/ground migrate --strict
 
         YAML);
     }


### PR DESCRIPTION
Releases **v1.10.1**. Merging this pushes the tag and runs the build — the CHANGELOG heading is already promoted.

## Why

`hkm ground init` wrote a CI workflow whose very first step could only ever fail. It ran `vendor/bin/hkm-ground check --here`, but this package declares

```json
"bin": ["bin/hkm-cli", "modules/ground/bin/ground"]
```

so what a plugin actually gets in `vendor/bin` is `ground`. Nothing has ever shipped a `hkm-ground` executable, and `alfacode-team/ground` is not published separately at all — it is a path repo inside this repository, reachable only because the kernel autoloads it. There was no version of this that worked.

The failure is worse than a typo because of where it lands: `composer install` succeeds, and only the step after it dies with `No such file or directory` (exit 127). That reads like the plugin under test is broken, not like the workflow named the wrong file.

Five plugin repositories had already been scaffolded with it (crypto, pageflow, tenancy, user, view).

## What changed

The generator emits `vendor/bin/ground`. That is the whole change — two lines in the heredoc at `Init.php:216` and `:222`.

## Verification

Not inferred from the YAML. Both steps were run against a real plugin checkout whose `vendor/` was installed from this package:

```
vendor/bin/ground check --here     → Clean. 0 error(s), 0 warning(s)
vendor/bin/ground migrate --strict → "ships no migrations", exit 0
```

The second matters: `ciWorkflow()` writes the migrate step unconditionally, including for plugins with no `database/` directory, and it returns SUCCESS there rather than failing.

Existing checkouts need the two lines changed by hand or `ground init` re-run; the generator cannot reach a workflow it already wrote.

389 tests, 723 assertions pass. PHPStan clean.
