### PR TITLE
Release v1.11.0 — the migration engine works on every driver again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-09-02
+
+### Fixed
+- **The migration engine only worked on MySQL** (`modules/let-migrate`). A
+  commit titled *"refactor: remove deprecated methods"* had restored `src/`,
+  `tests/` and the README byte-for-byte to their state before a day of merged
+  PR work — undoing four driver fixes and a Laravel-parity alias, and deleting
+  the eight tests that covered them. Nothing was failing that the deletion
+  fixed. Restored and carried forward:
+  - `ALTER TABLE` compiled MySQL syntax for every driver — additions batched
+    into one comma-separated statement, indexes added with `ADD KEY`, and drops
+    running columns BEFORE the indexes over them. A rollback written in the
+    correct order was reordered by the compiler into one that could not run
+    anywhere but MySQL, in the one direction nobody exercises until they
+    uninstall a plugin.
+  - PostgreSQL rejected `BOOLEAN DEFAULT 1`, and `modifyColumn()` emitted three
+    `;`-joined statements into a clause the extended query protocol refuses.
+  - SQLite could not add a foreign key to an existing table, and `modifyColumn()`
+    compiled `CREATE TABLE "__tmp_users" ()` — it was broken outright, because
+    the rebuild SQLite requires was driven from a blueprint holding only the
+    delta. It now reconstructs the full table from the `SchemaInspector`,
+    carrying existing indexes across and unwrapping defaults so a literal is
+    not re-quoted on every rebuild.
+  - Seeding a second database in one run died with *Cannot redeclare class* —
+    reachable the moment one run seeds once per driver, which is what
+    `hkm ground migrate` does.
+- **PostgreSQL: every schema lookup silently matched nothing.** The driver and
+  inspector used libpq's `$1` placeholders, which PDO neither understands nor
+  rejects — so `tableExists()` answered `false` for a table with seven columns,
+  and the inspector reported no columns, indexes or foreign keys. Anything
+  guarded by `hasTable()`, and everything built on schema diffing or dumping,
+  was quietly wrong on that driver. Found only by executing against a live
+  server.
+- **SQL Server emitted invalid T-SQL for every column addition and every
+  foreign key** — `ALTER TABLE … ADD COLUMN` (T-SQL has no `COLUMN` keyword
+  there) and `ON DELETE RESTRICT` (unimplemented; its actions are `NO ACTION`,
+  `CASCADE`, `SET NULL`, `SET DEFAULT`). Both are argued from the T-SQL
+  specification and are **not** verified against a live server — none was
+  reachable — but each replaces SQL the server rejects outright.
+- **`MigrationConfig`: singular `path` overrode plural `paths`** instead of
+  acting as its fallback, so a config carrying both silently ran one directory
+  and ignored the array — failing by doing less work rather than by erroring.
+- **`Blueprint::dropColumn()` accepted one column**, so `dropColumn('a', 'b')`
+  silently dropped only `a`. Now variadic, and the `drop*` methods chain.
+
+### Added
+- **`useCurrent()` / `useCurrentOnUpdate()` / `bigIncrements()`** — Laravel
+  parity, so a ported migration compiles unchanged. Without them the failure is
+  a fatal *Call to undefined method* raised the moment the migration runs,
+  during a deploy.
+- **`StatusRenderer`** — `migrate:status` as normalised data, aligned table
+  lines and JSON from one source, so the human and `--json` views cannot
+  disagree.
+- **`tests/Live` — the migration compiler executed against every reachable
+  engine.** Configured with `LETMIGRATE_DB_MYSQL` / `_PGSQL` / `_SQLSRV`
+  (`GROUND_DB_*` honoured); each run uses its own scratch database and drops it.
+  A driver that is unconfigured or not answering SKIPS with the reason, never
+  counted as a pass. This release was verified on SQLite, MariaDB 12.3 and
+  PostgreSQL 18; SQL Server skipped, and says so.
+
+### Changed
+- `docs/guides/18_MIGRATIONS.md` — `->useCurrent()` and `->useCurrentOnUpdate()`
+  now exist, so the anti-pattern entry saying they do not is corrected. The
+  `->index()` half stands: an index is declared on the Blueprint, not the
+  column.
+
+
 ## [1.10.1] - 2026-09-01
 
 ### Fixed

--- a/docs/guides/18_MIGRATIONS.md
+++ b/docs/guides/18_MIGRATIONS.md
@@ -240,9 +240,12 @@ $t->string('email')
 > primary key use the Blueprint method `$t->primary(['a', 'b'])`. Do not use
 > both on the same table.
 >
-> **There is no fluent `->index()` or `->useCurrent()` column modifier.**
-> Declare indexes with the Blueprint method `$t->index(['col'])` (see below),
-> and a current-timestamp default with `->default('CURRENT_TIMESTAMP')`.
+> **There is no fluent `->index()` column modifier.** Declare indexes with the
+> Blueprint method `$t->index(['col'])` (see below).
+>
+> `->useCurrent()` and `->useCurrentOnUpdate()` DO exist — Laravel-parity
+> aliases of `->default('CURRENT_TIMESTAMP')` and
+> `->onUpdateCurrentTimestamp()`. Either spelling compiles identically.
 
 ### Timestamps Behavior
 
@@ -841,7 +844,7 @@ echo $result->summary();
 ✗ Write migrations without matching down() rollback
 ✗ Forget to run data migrations inside transactions (or explicit transaction handling)
 ✗ Use --seed in refresh without wiring SeederRunner to MigrateRefreshCommand
-✗ Use a fluent `->index()` or `->useCurrent()` column modifier — they do NOT exist; use `$t->index(['col'])` and `->default('CURRENT_TIMESTAMP')`
+✗ Use a fluent `->index()` column modifier — it does NOT exist; use `$t->index(['col'])`
 ✗ Combine a column `->primary()` with a Blueprint `$t->primary([...])` on the same table — pick one (double PRIMARY KEY error)
 ✗ Reference `seed:run`/`seed:fresh`/`seed:status` or `migrate:make` — the real commands are `db:seed` and `make:migration`
 ✗ Hardcode database table names — use string literals, never interpolation


### PR DESCRIPTION
## What this is

`let-migrate` commit `9ac3a8e`, titled *"refactor: remove deprecated methods and improve column modification logic"*, was neither a refactor nor an improvement: it restored `src/`, `tests/` and `README.md` **byte-for-byte** to their state before a day of merged PR work (#8, #9, #10), undoing four driver fixes and a Laravel-parity alias, and deleting the eight tests that covered them.

Those eight tests **passed** before the deletion. Nothing was failing that it fixed.

This restores them and carries them forward with what running the compiler against real databases turned up.

## Verified by execution, not by reading compiled SQL

| Engine | Result |
|---|---|
| SQLite | ✅ full DDL lifecycle + 420-test suite |
| MariaDB 12.3.3 | ✅ full DDL lifecycle |
| PostgreSQL 18.6 | ✅ full DDL lifecycle |
| SQL Server | ⏭️ **not run** — no server reachable, `sqlsrv` extension absent |

Every defect fixed here compiled cleanly, read correctly, and was refused by an engine. None was visible to `php -l`, to a unit test that inspects the compiled string, or to a fake that records SQL without executing it.

## The one found only by running it

PostgreSQL's driver and inspector wrote their queries with libpq's `$1` placeholders. PDO does not understand them — and, the dangerous part, **does not reject them**:

```
libpq $1 style   -> NO ROW (silently wrong)
PDO ? style      -> row found
```

So `tableExists()` answered `false` for a table with seven columns, and the inspector reported no columns, no indexes and no foreign keys. Anything guarded by `hasTable()`, and everything built on schema diffing or dumping, was quietly wrong on that driver.

## New: `tests/Live`

The compiler executed against every reachable engine, configured with `LETMIGRATE_DB_MYSQL` / `_PGSQL` / `_SQLSRV` (`GROUND_DB_*` honoured). Each run creates its own scratch database and drops it.

Registered in the **default** suite deliberately. A driver that is unconfigured or not answering **skips with the reason** — never silently dropped, never counted as a pass. *"3 of 4 engines were not tested"* is the most important line such a run can print, and it is worthless if a missing server looks like a green tick.

## Known gap, stated plainly

The two SQL Server fixes — `ADD` instead of `ADD COLUMN`, and `RESTRICT` → `NO ACTION` — are argued from the T-SQL specification, not demonstrated. Both replace SQL that server rejects outright, so they cannot be worse than what shipped. Point `LETMIGRATE_DB_SQLSRV` at any instance and the Live suite settles it in one run.

## Merging this releases

`auto-release.yml` fires on a push to `main` touching `CHANGELOG.md`, reads `1.11.0`, creates and pushes `v1.11.0`, and calls `release.yml`. `v1.11.0` is confirmed free. Do not hand-edit the Homebrew `sha256` — the `homebrew` job rewrites it from the tarball GitHub builds from the tag.
