### PR TITLE
chore(homebrew): point the formula at v1.11.0

### DIFF
--- a/HomebrewFormula/hkm.rb
+++ b/HomebrewFormula/hkm.rb
@@ -34,8 +34,8 @@
 class Hkm < Formula
   desc "CLI for the HKM kernel, a modular PHP service platform"
   homepage "https://github.com/AlfaCode-Team/hkm-kernel"
-  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.9.0/hkm-kernel-1.9.0-macos-universal.tar.gz"
-  sha256 "922c858200b8f3f3aa380f9a1195aee7af14092d1ff54f1d16587972ad8c9e05"
+  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.11.0/hkm-kernel-1.11.0-macos-universal.tar.gz"
+  sha256 "a9e4359af69629c0ccdcaeaa76b121a080c61cac8bea5bb1b3f7558b3bc11168"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
Generated by the `Bump Homebrew formula` job of the v1.11.0 release. It could not push to `main` (branch protection), so it left the commit on this branch — and the follow-up "open a pull request instead" step did not produce one.

## The formula on `main` is three releases stale

```
main today:  v1.9.0
released:    v1.10.0, v1.10.1, v1.11.0
```

`brew install hkm` has been serving **v1.9.0** since v1.9.0 shipped. `homebrew/bump-v1.10.0` and `homebrew/bump-v1.10.1` are sitting unmerged with no PR either — this one supersedes both, since the formula holds a single `url` + `sha256` and this points at the newest release. Those two branches can be deleted once this lands.

## The hash was verified independently

Not trusted from the workflow — the release tarball was downloaded and hashed:

```
url:      https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.11.0/hkm-kernel-1.11.0-macos-universal.tar.gz
claimed:  a9e4359af69629c0ccdcaeaa76b121a080c61cac8bea5bb1b3f7558b3bc11168
actual:   a9e4359af69629c0ccdcaeaa76b121a080c61cac8bea5bb1b3f7558b3bc11168   ✅ match
```

Nothing here was hand-edited. The formula header forbids it, and it would be impossible anyway: the digest is of a tarball GitHub builds *from the tag*, so it cannot exist before the release does.

## Worth a follow-up

Three consecutive releases pushed a bump branch and produced no PR, so the loud-failure annotation added in #128 is firing into a void that nobody acts on. Whatever grants that step `pull-requests: write` looks like it stopped working after v1.9.0.
