### PR TITLE
chore(homebrew): point the formula at v1.10.1

### DIFF
--- a/HomebrewFormula/hkm.rb
+++ b/HomebrewFormula/hkm.rb
@@ -34,8 +34,8 @@
 class Hkm < Formula
   desc "CLI for the HKM kernel, a modular PHP service platform"
   homepage "https://github.com/AlfaCode-Team/hkm-kernel"
-  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.9.0/hkm-kernel-1.9.0-macos-universal.tar.gz"
-  sha256 "922c858200b8f3f3aa380f9a1195aee7af14092d1ff54f1d16587972ad8c9e05"
+  url "https://github.com/AlfaCode-Team/hkm-kernel/releases/download/v1.10.1/hkm-kernel-1.10.1-macos-universal.tar.gz"
+  sha256 "4be7a3d181238083838be2d333f9770ac35a246ff110df03a00a61193883a710"
   license "MIT"
 
   livecheck do


### PR DESCRIPTION
Generated by the `Bump Homebrew formula` job of the **v1.10.1** release. The job could not push to `main` (branch protection) and the follow-up "open a pull request instead" step produced nothing, so this commit has been sitting on a branch unmerged since v1.10.1 shipped.

## ⚠️ Superseded by #151 — do not merge after it

The formula holds a single `url` + `sha256`, so all three pending bumps edit the same two lines:

| PR | Points the formula at |
|---|---|
| #152 | v1.10.0 |
| this one | v1.10.1 |
| **#151** | **v1.11.0 — the current release** |

Merging #151 alone brings the formula fully up to date. Merging this one *after* #151 would **downgrade** `brew install hkm` from v1.11.0 back to v1.10.1.

It is opened for the record — so the backlog is visible rather than sitting in an unreferenced branch — and the expected outcome is **close it, delete the branch**.

## Hash verified

Not trusted from the workflow; the release tarball was downloaded and hashed:

```
sha256  4be7a3d181238083838be2d333f9770ac35a246ff110df03a00a61193883a710   ✅ matches the v1.10.1 tarball
```
