### PR TITLE
release: v1.12.0 — a deployed project is readable by the account that serves it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-09-02
+
+### Fixed
+- **A project installed with `--production --owner=` still could not be served
+  by PHP-FPM.** The pass only ever touched `var/` and `userdata/`, so every
+  directory a request actually reads — `app/public_html`, `src/`, `vendor/`,
+  `plugins/` — kept the deploying user's ownership and whatever mode the clone
+  arrived with. The pool could write logs it was never going to reach the code
+  to produce. Three separate reasons a boot failed, each fixed:
+  - the pass now covers the WHOLE project tree, and runs LAST — after
+    `composer install` and the plugin fetch, both of which create `vendor/` and
+    `plugins/` as whoever ran the command. Running at step 3, as it did, meant
+    the two largest directories in the project were created *after* the
+    permissions were "fixed".
+  - `.env` was chmod'd `0600`. PHP-FPM running as another account cannot read
+    `APP_KEY` through that, and the boot fails on a file whose mode bits look
+    deliberate. It is now `0640` — group-readable, never group-writable, never
+    world-anything.
+  - nothing reported that the pool could not TRAVERSE to the project. Reaching
+    `app/public_html/index.php` needs execute on every parent directory, and a
+    home directory is `0700` on a stock Debian install — unfixable from inside
+    the project, so the offending parents are now named (reported only, never
+    changed).
+
+- **The installed kernel was left at whatever the installing account's umask
+  produced** (`tools/install.sh`). `/opt/hkm-kernel` is shared infrastructure —
+  every PHP-FPM pool on the box loads its PHP out of that one tree, and none of
+  those pools runs as the account that installed it. With `umask 027` or `077`
+  the whole tree landed 0750/0700 and every site died with "Permission denied"
+  on a kernel file, while the install reported success because the installer
+  could obviously read what it had just written. The installer now normalises
+  the tree it lays down: directories traversable, files readable, and anything
+  that WAS executable still executable.
+
+### Changed
+- `hkm install --production` / `--owner=` now apply a split-ownership model:
+  code owned by the deploy user and only READABLE through the web server's
+  group (`2750`/`0640`), `var/` and `userdata/` group-writable (`2770`/`0660`).
+  EVERY directory carries setgid, code included: the group is the only thing
+  granting the pool access, so a file created later — a log written at 3am, a
+  file a `git pull` lands — would otherwise take the creating account's primary
+  group and drop out of the share, and each deploy would silently un-share
+  whatever it touched.
+  Code is never group-writable in either profile — an FPM pool that can rewrite
+  the PHP it executes turns any file-write bug into code execution. An
+  already-executable file keeps its exec bit (re-granted only where the profile
+  grants read, so `bin/psp` and `vendor/bin/*` survive at `0750`, not `0751`),
+  and `.git` is skipped by both the chown and the chmod.
+- The pass re-stats what it changed and reports any mode the filesystem
+  refused, instead of reporting success for a chmod the kernel rejected.
+
+
 ## [1.11.0] - 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-09-02
+
+### Fixed
+- **The migration engine only worked on MySQL** (`modules/let-migrate`). A
+  commit titled *"refactor: remove deprecated methods"* had restored `src/`,
+  `tests/` and the README byte-for-byte to their state before a day of merged
+  PR work — undoing four driver fixes and a Laravel-parity alias, and deleting
+  the eight tests that covered them. Nothing was failing that the deletion
+  fixed. Restored and carried forward:
+  - `ALTER TABLE` compiled MySQL syntax for every driver — additions batched
+    into one comma-separated statement, indexes added with `ADD KEY`, and drops
+    running columns BEFORE the indexes over them. A rollback written in the
+    correct order was reordered by the compiler into one that could not run
+    anywhere but MySQL, in the one direction nobody exercises until they
+    uninstall a plugin.
+  - PostgreSQL rejected `BOOLEAN DEFAULT 1`, and `modifyColumn()` emitted three
+    `;`-joined statements into a clause the extended query protocol refuses.
+  - SQLite could not add a foreign key to an existing table, and `modifyColumn()`
+    compiled `CREATE TABLE "__tmp_users" ()` — it was broken outright, because
+    the rebuild SQLite requires was driven from a blueprint holding only the
+    delta. It now reconstructs the full table from the `SchemaInspector`,
+    carrying existing indexes across and unwrapping defaults so a literal is
+    not re-quoted on every rebuild.
+  - Seeding a second database in one run died with *Cannot redeclare class* —
+    reachable the moment one run seeds once per driver, which is what
+    `hkm ground migrate` does.
+- **PostgreSQL: every schema lookup silently matched nothing.** The driver and
+  inspector used libpq's `$1` placeholders, which PDO neither understands nor
+  rejects — so `tableExists()` answered `false` for a table with seven columns,
+  and the inspector reported no columns, indexes or foreign keys. Anything
+  guarded by `hasTable()`, and everything built on schema diffing or dumping,
+  was quietly wrong on that driver. Found only by executing against a live
+  server.
+- **SQL Server emitted invalid T-SQL for every column addition and every
+  foreign key** — `ALTER TABLE … ADD COLUMN` (T-SQL has no `COLUMN` keyword
+  there) and `ON DELETE RESTRICT` (unimplemented; its actions are `NO ACTION`,
+  `CASCADE`, `SET NULL`, `SET DEFAULT`). Both are argued from the T-SQL
+  specification and are **not** verified against a live server — none was
+  reachable — but each replaces SQL the server rejects outright.
+- **`MigrationConfig`: singular `path` overrode plural `paths`** instead of
+  acting as its fallback, so a config carrying both silently ran one directory
+  and ignored the array — failing by doing less work rather than by erroring.
+- **`Blueprint::dropColumn()` accepted one column**, so `dropColumn('a', 'b')`
+  silently dropped only `a`. Now variadic, and the `drop*` methods chain.
+
+### Added
+- **`useCurrent()` / `useCurrentOnUpdate()` / `bigIncrements()`** — Laravel
+  parity, so a ported migration compiles unchanged. Without them the failure is
+  a fatal *Call to undefined method* raised the moment the migration runs,
+  during a deploy.
+- **`StatusRenderer`** — `migrate:status` as normalised data, aligned table
+  lines and JSON from one source, so the human and `--json` views cannot
+  disagree.
+- **`tests/Live` — the migration compiler executed against every reachable
+  engine.** Configured with `LETMIGRATE_DB_MYSQL` / `_PGSQL` / `_SQLSRV`
+  (`GROUND_DB_*` honoured); each run uses its own scratch database and drops it.
+  A driver that is unconfigured or not answering SKIPS with the reason, never
+  counted as a pass. This release was verified on SQLite, MariaDB 12.3 and
+  PostgreSQL 18; SQL Server skipped, and says so.
+
+### Changed
+- `docs/guides/18_MIGRATIONS.md` — `->useCurrent()` and `->useCurrentOnUpdate()`
+  now exist, so the anti-pattern entry saying they do not is corrected. The
+  `->index()` half stands: an index is declared on the Blueprint, not the
+  column.
+
+
 ## [1.10.1] - 2026-09-01
 
 ### Fixed

--- a/docs/guides/18_MIGRATIONS.md
+++ b/docs/guides/18_MIGRATIONS.md
@@ -240,9 +240,12 @@ $t->string('email')
 > primary key use the Blueprint method `$t->primary(['a', 'b'])`. Do not use
 > both on the same table.
 >
-> **There is no fluent `->index()` or `->useCurrent()` column modifier.**
-> Declare indexes with the Blueprint method `$t->index(['col'])` (see below),
-> and a current-timestamp default with `->default('CURRENT_TIMESTAMP')`.
+> **There is no fluent `->index()` column modifier.** Declare indexes with the
+> Blueprint method `$t->index(['col'])` (see below).
+>
+> `->useCurrent()` and `->useCurrentOnUpdate()` DO exist — Laravel-parity
+> aliases of `->default('CURRENT_TIMESTAMP')` and
+> `->onUpdateCurrentTimestamp()`. Either spelling compiles identically.
 
 ### Timestamps Behavior
 
@@ -841,7 +844,7 @@ echo $result->summary();
 ✗ Write migrations without matching down() rollback
 ✗ Forget to run data migrations inside transactions (or explicit transaction handling)
 ✗ Use --seed in refresh without wiring SeederRunner to MigrateRefreshCommand
-✗ Use a fluent `->index()` or `->useCurrent()` column modifier — they do NOT exist; use `$t->index(['col'])` and `->default('CURRENT_TIMESTAMP')`
+✗ Use a fluent `->index()` column modifier — it does NOT exist; use `$t->index(['col'])`
 ✗ Combine a column `->primary()` with a Blueprint `$t->primary([...])` on the same table — pick one (double PRIMARY KEY error)
 ✗ Reference `seed:run`/`seed:fresh`/`seed:status` or `migrate:make` — the real commands are `db:seed` and `make:migration`
 ✗ Hardcode database table names — use string literals, never interpolation

--- a/tools/docs/hkm-cli-usage.md
+++ b/tools/docs/hkm-cli-usage.md
@@ -80,8 +80,8 @@ hkm install [path|name] [options]
 --no-plugins               skip fetching the bootstrap's plugins
 --no-chmod                 skip fixing var/ and userdata/ mode bits
 --verify-plugins           run each plugin's own test suite while installing (slow)
---production, --prod       tighter mode bits (dir 0750/file 0640, no world access)
---owner=<user>[:<group>]   chown var/ and userdata/ to this user[:group] (needs root/sudo)
+--production, --prod       harden the WHOLE tree: code 0750/0640, var+userdata 2770/0660
+--owner=<user>[:<group>]   chown the whole project to this user[:group] (needs root/sudo)
 ```
 
 What it does, in order: registers the project in the kernel registry; recreates
@@ -95,33 +95,100 @@ right after scaffolding.
 
 ### `--production` / `--owner` — correct permissions AND ownership on a server
 
-Dev mode chmods `var/`/`userdata/` to `0775`/`0664` (group-writable, world
-readable) and stops there — good enough when the files are already owned by
-whoever is running `hkm`. On a real server that is rarely the case: the web
-server / PHP-FPM pool usually runs as its own account (`www-data`, `nginx`,
-`app`, …), and CHMOD alone cannot fix that — only `chown` can.
+Dev mode chmods `var/`/`userdata/` to `0775`/`0664` and stops there — good
+enough when the files are already owned by whoever is running `hkm`. On a real
+server that is never the case: the web server / PHP-FPM pool runs as its own
+account (`www-data`, `nginx`, `app`, …), and it needs to READ every PHP file in
+the project and EXECUTE (traverse) every directory holding one — not just write
+to `var/`. Chmod alone cannot arrange that; only `chown` can.
 
-- `--production` swaps the mode bits for `0750`/`0640` (owner + group only, no
-  "other" access at all). It does **not** guess an owner — correctness matters
-  more than convenience here, and guessing wrong on a shared box is worse than
-  asking.
-- `--owner=<user>[:<group>]` recursively `chown`s `var/` and `userdata/` to
-  that account. It is passed straight through to the system `chown`, so
-  `www-data`, `www-data:www-data` and `:www-data` (group only) all work.
-  Requires root/sudo unless the process already owns the target files — a
-  failed chown is reported per-directory, never swallowed silently.
+Passing `--production` or `--owner=` runs a **hardening pass over the whole
+project**, as the LAST step of the install — after `composer install` and the
+plugin fetch, because both create files (`vendor/`, `plugins/`) owned by
+whoever ran the command.
+
+The model is **split ownership**: the deploy account keeps the code, the pool
+reaches it through the GROUP.
+
+| Path | `--production` | default (`--owner` alone) |
+|---|---|---|
+| directories holding code | `2750` | `2755` |
+| files holding code | `0640` | `0644` |
+| an already-executable file (`bin/psp`, `vendor/bin/*`) | `0750` | `0755` |
+| `var/`, `userdata/` directories | `2770` | `2775` |
+| `var/`, `userdata/` files | `0660` | `0664` |
+| `.env` | `0640` | `0640` |
+| `.git` | untouched | untouched |
+
+**There is no chmod-only version of this.** Opening the tree with
+`chmod -R o+rX` looks like it would avoid the chown, and it cannot: `.env`
+carries `APP_KEY` and the database password, so world-readable is the one thing
+it must never be — and `var/cache/manifests` needs the pool to WRITE (the boot
+compiles manifests into it on every request unless `BOOT_CACHE=1`), which no
+amount of "execute for others" grants. Reaching the tree through a shared GROUP
+is what covers both.
+
+Five details are load-bearing:
+
+- **`.env` is `0640`, never `0600`.** PHP-FPM has to read `APP_KEY`, and a
+  `0600` `.env` owned by the deploy user is the single most common reason a tree
+  that runs fine from the shell fails to boot under a pool running as another
+  account. Group-readable, never group-writable, never world-anything.
+- **Code is never group-writable**, in either profile. An FPM pool that can
+  rewrite the PHP it is executing turns any file-write bug into remote code
+  execution. Only `var/` and `userdata/` — which the application genuinely
+  writes — are group-writable.
+- **Every directory carries setgid** (the `2` prefix), code included. The group
+  is the only thing granting the pool access, and a file created later — a log
+  the pool writes at 3am, a file a `git pull` lands — otherwise takes the
+  creating account's primary group and drops out of the share. Without it every
+  deploy silently un-shares whatever it touched, and the site 500s on a file
+  that was readable an hour ago.
+- **An already-executable file keeps its exec bit**, re-granted only where the
+  profile grants read (so `0640` → `0750`, never `0751`). A flat `chmod 0640`
+  over the tree strips `bin/psp` and `vendor/bin/*`, and the install looks like
+  it worked right up until the first invocation.
+
+`.git` is skipped by both the chown and the chmod: it holds the whole history —
+every secret ever committed and later removed included — nothing in a request
+path reads it, and leaving it alone means the deploy user can still `git pull`
+after a `sudo hkm install`.
+
+After the pass the command **re-stats what it changed** and reports any mode
+that did not actually take (a filesystem refusing setgid, an ACL, not being
+root), rather than reporting success for a chmod the kernel rejected.
+
+It also checks whether the pool can REACH the project at all: opening
+`/home/deploy/shop/app/public_html/index.php` needs execute on every directory
+down that path, and a home directory is `0700` on a stock Debian install.
+Nothing inside the project can fix that, so the offending parents are named —
+and reported only, never changed: widening a directory outside the project is
+the operator's call.
+
+- `--owner=<user>[:<group>]` is passed straight through to the system `chown`,
+  so `www-data`, `deploy:www-data` and `:www-data` (group only) all work.
+  Requires root/sudo unless the process already owns the files; a failed chown
+  is reported, never swallowed silently.
+- **`--owner=:www-data` (group only) is the form to reach for when the tree is
+  deployed by a CI account** — a Bitbucket/Jenkins user, a `git pull` from a
+  developer's login. It changes the GROUP and leaves the OWNER alone, so the
+  deploy account keeps writing to its own checkout while the pool gets in
+  through the group. Re-run it after a deploy that adds files; setgid keeps the
+  ones created inside existing directories correct on its own.
 - Set `HKM_PROD_OWNER` once in your deploy environment to avoid repeating
   `--owner=` on every run; an explicit `--owner=` flag always wins.
-- `--production` with no `--owner` (and no `HKM_PROD_OWNER`) still tightens the
-  mode bits, but warns that ownership was left unchanged instead of guessing.
+- `--production` with no `--owner` (and no `HKM_PROD_OWNER`) still applies the
+  mode bits, but warns that ownership was left unchanged instead of guessing —
+  correctness matters more than convenience, and guessing wrong on a shared box
+  is worse than asking.
 
 ```bash
 cd my-shop && hkm install       # after a fresh git clone
 hkm install ./my-shop
 hkm install shop                # by registered name
 hkm install --no-install        # vendor/ already cached — skip composer
-sudo hkm install --production --owner=www-data:www-data   # on a server
-HKM_PROD_OWNER=www-data:www-data sudo hkm install --production
+sudo hkm install --production --owner=deploy:www-data     # on a server
+HKM_PROD_OWNER=deploy:www-data sudo hkm install --production
 ```
 
 ---

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -226,6 +226,25 @@ if [ -d "$DEST" ]; then mv "$DEST" "$OLD"; fi
 mv "$NEW" "$DEST"
 rm -rf "$OLD"
 
+# ── make the installed kernel readable by the accounts that RUN it ──────────
+# The kernel is SHARED infrastructure: every PHP-FPM pool on this box loads its
+# PHP out of this one tree, and those pools run as their own accounts
+# (www-data, nginx, a per-site user) — never as the account that ran this
+# installer. `cp -R` above applies the INSTALLING account's umask, so on a box
+# with umask 027 or 077 the whole tree lands mode 0750 or 0700 and every site
+# dies with "Permission denied" on a kernel file it can see but not open. The
+# install itself reports success, because the installer can obviously read what
+# it just wrote.
+#
+# Normalise instead of trusting the umask: directories traversable, files
+# readable, and anything that WAS executable still executable (bin/psp,
+# vendor/bin/* — a flat 0644 pass strips them and the failure only shows up at
+# the first invocation). There are no secrets in here; a project's .env lives
+# in the project, not in the kernel.
+find "$DEST" -type d -exec chmod 755 {} + 2>/dev/null || true
+find "$DEST" -type f ! -perm -u+x -exec chmod 644 {} + 2>/dev/null || true
+find "$DEST" -type f -perm -u+x -exec chmod 755 {} + 2>/dev/null || true
+
 # Stage beside the destination, then rename over it. A plain `cp` truncates
 # and writes INTO the existing file, which fails with "Text file busy" the
 # moment that exact binary is the one currently running this script — i.e.

--- a/tools/src/commands/install.zig
+++ b/tools/src/commands/install.zig
@@ -16,6 +16,9 @@
 //!   5. `composer install`
 //!   6. fetch every plugin the project's own bootstrap wires (mirrors what
 //!      `hkm new` does right after scaffolding — see lib/plugin_provision.zig)
+//!   7. with --production / --owner: chown and chmod the WHOLE project for the
+//!      web server's account — last, because steps 5 and 6 create vendor/ and
+//!      plugins/ as whoever ran the command
 //!
 //! Every step besides directory creation can be skipped with a --no-* flag, for
 //! a CI image that already provisions one of them another way.
@@ -65,17 +68,18 @@ const Options = struct {
     chmod: bool = true,
     verify_plugins: bool = false,
     help: bool = false,
-    /// --production: var/ and userdata/ get tighter mode bits (dir 0750, file
-    /// 0640 — no "other" access) instead of the dev defaults (dir 0775, file
-    /// 0664), and a chown failure (see `owner`) is reported per-path instead
-    /// of only implied by "no --owner given".
+    /// --production: run the hardening pass over the WHOLE project with no
+    /// "other" access at all — code 0750/0640, var+userdata 2770/0660, .env
+    /// 0640. Without it the pass still runs whenever `owner` is set, using the
+    /// group-and-world-readable dev modes (0775/0664).
     production: bool = false,
-    /// --owner=<user>[:<group>] (also HKM_PROD_OWNER) — chown var/ and
-    /// userdata/ to this user[:group], typically the account your web server
-    /// / PHP-FPM pool actually runs as. Passed straight to the system `chown`,
-    /// so `user`, `user:group` and `:group` (group-only) all work. Requires
-    /// root/sudo unless the process already owns the target files. Applies
-    /// whenever set, independent of --production and of --no-chmod.
+    /// --owner=<user>[:<group>] (also HKM_PROD_OWNER) — chown the whole
+    /// project to this user[:group], typically `deploy:www-data`: the deploy
+    /// account keeps the code, the web server / PHP-FPM pool reaches it through
+    /// the group. Passed straight to the system `chown`, so `user`,
+    /// `user:group` and `:group` (group-only) all work. Requires root/sudo
+    /// unless the process already owns the target files. Setting it triggers
+    /// the hardening pass on its own, independent of --production.
     owner: ?[]const u8 = null,
 };
 
@@ -136,8 +140,8 @@ fn printHelp() void {
     prompt.item("--no-plugins", "skip fetching the bootstrap's plugins");
     prompt.item("--no-chmod", "skip fixing var/ and userdata/ mode bits");
     prompt.item("--verify-plugins", "run each plugin's own test suite while installing (slow)");
-    prompt.item("--production, --prod", "tighter mode bits (dir 0750/file 0640, no world access)");
-    prompt.item("--owner=<user>[:<group>]", "chown var/ and userdata/ to this user[:group] (needs root/sudo)");
+    prompt.item("--production, --prod", "harden the WHOLE tree: code 0750/0640, var+userdata 2770/0660");
+    prompt.item("--owner=<user>[:<group>]", "chown the whole project to this user[:group] (needs root/sudo)");
     prompt.item("--help, -h", "show this help");
     prompt.blank();
     prompt.section("Environment");
@@ -146,7 +150,8 @@ fn printHelp() void {
     prompt.blank();
     prompt.section("Examples");
     prompt.note("cd my-shop && hkm install");
-    prompt.note("hkm install --production --owner=www-data:www-data");
+    prompt.note("sudo hkm install --production --owner=deploy:www-data");
+    prompt.muted("code readable+traversable by the pool's group, var/ and userdata/ writable, .env 0640.");
     prompt.outro("Run this once after `git clone` / `git pull` on a machine new to the project");
 }
 
@@ -198,21 +203,13 @@ pub fn run(allocator: std.mem.Allocator, io: Io, env: *EnvMap, args: []const []c
         prompt.muted("Runtime directories already present");
     }
 
-    // 3. make sure they (and anything already inside them) are writable, and
-    //    — in --production, or whenever --owner/HKM_PROD_OWNER is set — owned
-    //    by the right user[:group] (typically the web server's own account).
+    // 3. make sure they (and anything already inside them) are writable by the
+    //    account running this command — composer and the plugin fetch below
+    //    both write into the project, so this cannot wait for the hardening
+    //    pass in step 7.
     if (opts.chmod) {
-        fixPermissions(allocator, io, root, opts.production);
-        prompt.ok(if (opts.production)
-            "var/ and userdata/ set to production-safe permissions (0750/0640)"
-        else
-            "var/ and userdata/ set to writable permissions");
-    }
-    if (opts.owner) |owner| {
-        if (owner.len > 0) fixOwnership(allocator, io, env, root, owner);
-    } else if (opts.production) {
-        prompt.warn("--production: no --owner given (and HKM_PROD_OWNER is unset) — ownership of var/ and userdata/ left unchanged.");
-        prompt.muted("pass --owner=<user>[:<group>] — typically your web server's account, e.g. www-data:www-data.");
+        fixPermissions(allocator, io, root);
+        prompt.muted("var/ and userdata/ set to writable permissions");
     }
 
     // 4. .env — create from .env.example if absent, generate APP_KEY if empty.
@@ -242,6 +239,17 @@ pub fn run(allocator: std.mem.Allocator, io: Io, env: *EnvMap, args: []const []c
         plugin_assets.publishEnabled(allocator, io, env, root) catch {
             prompt.warn("Could not publish plugin assets — run 'hkm plugins enable <p>' later.");
         };
+    }
+
+    // 7. LAST — ownership and mode bits for the WHOLE project tree.
+    //
+    //    Deliberately after composer and the plugin fetch: both create files
+    //    (vendor/, plugins/) owned by whoever ran this command, so a pass any
+    //    earlier would leave exactly the directories a request has to read
+    //    owned by the wrong account — the reason a server boot fails under
+    //    PHP-FPM while the same tree runs fine from the shell.
+    if (opts.production or opts.owner != null) {
+        hardenProject(allocator, io, env, root, opts.production, opts.owner);
     }
 
     prompt.note("");
@@ -361,62 +369,309 @@ fn ensureRuntimeDirs(allocator: std.mem.Allocator, io: Io, root: []const u8) !us
 /// `production` swaps the dev-friendly 0775/0664 for tighter 0750/0640 (no
 /// "other" access) — correct ownership (see fixOwnership) is what actually
 /// grants the web server access, so removing world access does not break it.
-fn fixPermissions(allocator: std.mem.Allocator, io: Io, root: []const u8, production: bool) void {
-    const dir_mode: u32 = if (production) 0o750 else 0o775;
-    const file_mode: u32 = if (production) 0o640 else 0o664;
-    for ([_][]const u8{ "var", "userdata" }) |sub| {
+/// Step 3: make `var/` and `userdata/` writable by the account running this
+/// command, so composer and the plugin fetch can write into them. Deliberately
+/// NOT the production mode bits — those are applied by the hardening pass at
+/// the end, once every file that pass has to cover actually exists.
+fn fixPermissions(allocator: std.mem.Allocator, io: Io, root: []const u8) void {
+    for (writable_subdirs) |sub| {
         const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, sub }) catch continue;
         if (!util.dirExists(Dir.cwd(), io, path)) continue;
-        util.chmodTreeWritable(allocator, io, path, dir_mode, file_mode, 8);
+        util.chmodTreeWritable(allocator, io, path, 0o775, 0o664, 8);
     }
+}
+
+// --------------------------------------------------------------------------
+// hardening — the whole project tree, for a web server account
+// --------------------------------------------------------------------------
+
+/// The subtrees the application WRITES to at runtime. Everything else in a
+/// project is code the request only ever reads.
+const writable_subdirs = [_][]const u8{ "var", "userdata" };
+
+/// Never touched by the hardening pass. `.git` holds the whole history — every
+/// secret ever committed and later removed included — and nothing in a request
+/// path reads it, so widening it to the web server's group buys nothing and
+/// gives away everything. It also stays owned by whoever cloned the repo, so a
+/// later `git pull` as the deploy user still works after a `sudo hkm install`.
+const harden_skip = [_][]const u8{".git"};
+
+/// Mode bits for a hardening pass, in the split-ownership model this command
+/// is built around: the code stays owned by the DEPLOY user and the web server
+/// account reaches it through the GROUP.
+///
+/// That is why every mode here grants the group read and directory-execute but
+/// never write on code — an FPM pool that can rewrite the PHP it is executing
+/// turns any file-write bug into remote code execution. Only `var/` and
+/// `userdata/`, which the application genuinely writes, are group-writable, and
+/// their directories carry setgid (`2` prefix) so a log file the pool creates
+/// at 3am inherits the group instead of becoming unreadable to the deploy user.
+const Modes = struct {
+    /// directories holding code
+    dir: u32,
+    /// regular files holding code
+    file: u32,
+    /// directories under var/ and userdata/ — setgid + group-writable
+    writable_dir: u32,
+    /// regular files under var/ and userdata/
+    writable_file: u32,
+    /// .env and friends — group-READABLE, because PHP-FPM has to read APP_KEY,
+    /// and never world-readable whichever profile is in force. A 0600 .env is
+    /// the single most common reason a tree that runs from the shell fails to
+    /// boot under a pool running as another account.
+    secret: u32 = 0o640,
+
+    fn of(production: bool) Modes {
+        return if (production) .{
+            // setgid on code directories too, not just the writable ones: the
+            // group is the only thing granting the pool access, and a deploy
+            // that lands new files (a git pull, a plugin fetch) creates them
+            // with the DEPLOYING account's primary group unless the parent
+            // directory says otherwise. Without it every deploy silently
+            // un-shares whatever it touched, and the site 500s on a file that
+            // was readable an hour ago.
+            .dir = 0o2750,
+            .file = 0o640,
+            .writable_dir = 0o2770,
+            .writable_file = 0o660,
+        } else .{
+            // World-readable, which is the point of the non-production profile
+            // — but NOT group-writable on code. The group here is the web
+            // server's, and 0664 source would let the pool rewrite the PHP it
+            // is executing. Only var/ and userdata/ below are group-writable.
+            .dir = 0o2755,
+            .file = 0o644,
+            .writable_dir = 0o2775,
+            .writable_file = 0o664,
+        };
+    }
+};
+
+/// Apply ownership and then mode bits to the entire project.
+///
+/// Order matters: chown FIRST, chmod second. POSIX lets chown clear the setuid
+/// and setgid bits, so a chown running after the chmod would strip the setgid
+/// this pass puts on `var/` — and the symptom (files the pool creates being
+/// unreadable to the deploy user) shows up days later, nowhere near the cause.
+fn hardenProject(
+    allocator: std.mem.Allocator,
+    io: Io,
+    env: *EnvMap,
+    root: []const u8,
+    production: bool,
+    owner: ?[]const u8,
+) void {
+    if (@import("builtin").os.tag == .windows) {
+        prompt.warn("--production/--owner adjust POSIX mode bits and ownership — skipped on Windows.");
+        return;
+    }
+
+    prompt.note("");
+    if (owner) |o| {
+        if (o.len > 0) fixOwnership(allocator, io, env, root, o);
+    } else {
+        prompt.warn("--production: no --owner given (and HKM_PROD_OWNER is unset) — ownership left unchanged.");
+        prompt.muted("pass --owner=<user>[:<group>] — typically your web server's account, e.g. deploy:www-data.");
+    }
+
+    const m = Modes.of(production);
+    hardenTree(allocator, io, root, m);
+    prompt.ok(std.fmt.allocPrint(
+        allocator,
+        "Permissions applied — code {o}/{o}, var+userdata {o}/{o}, .env {o}",
+        .{ m.dir, m.file, m.writable_dir, m.writable_file, m.secret },
+    ) catch "Permissions applied");
+
+    verifyModes(allocator, io, root, m);
+    reportTraversal(allocator, io, root);
+}
+
+/// Re-stat the paths that decide whether the application boots, and say so when
+/// a mode did not actually take.
+///
+/// Every chmod in this pass is best-effort by contract (`util.chmodPath`
+/// swallows the error), which is right for one file deep in `vendor/` and wrong
+/// for `var/` — a setgid bit refused because the process is not in the target
+/// group leaves a tree that looks hardened and is not. The kernel will not tell
+/// you either: it fails later, at the first write, as a permission error on a
+/// path whose ownership was just reported as correct.
+fn verifyModes(allocator: std.mem.Allocator, io: Io, root: []const u8, m: Modes) void {
+    var bad: std.ArrayList([]const u8) = .empty;
+
+    const Want = struct { path: []const u8, mode: u32 };
+    var wants: std.ArrayList(Want) = .empty;
+    wants.append(allocator, .{ .path = root, .mode = m.dir }) catch return;
+    for (writable_subdirs) |sub| {
+        const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, sub }) catch continue;
+        if (util.dirExists(Dir.cwd(), io, path)) wants.append(allocator, .{ .path = path, .mode = m.writable_dir }) catch {};
+    }
+    const env_path = std.fmt.allocPrint(allocator, "{s}/.env", .{root}) catch null;
+    if (env_path) |ep| {
+        if (util.fileExists(io, ep)) wants.append(allocator, .{ .path = ep, .mode = m.secret }) catch {};
+    }
+
+    for (wants.items) |w| {
+        const actual = util.statMode(io, w.path) orelse continue;
+        if (actual == w.mode) continue;
+        bad.append(allocator, std.fmt.allocPrint(
+            allocator,
+            "  {s} — wanted {o}, is {o}",
+            .{ w.path, w.mode, actual },
+        ) catch continue) catch {};
+    }
+
+    if (bad.items.len == 0) return;
+
+    prompt.warn("Some mode bits did not take — the pass reports what it asked for, not what the filesystem accepted:");
+    for (bad.items) |line| prompt.muted(line);
+    prompt.muted("Usually: not running as root/sudo, a filesystem that refuses setgid, or an ACL overriding the mode.");
+}
+
+/// Walk the project root once, dispatching each top-level entry to the mode
+/// pair that belongs to it: `var/` and `userdata/` get the writable set,
+/// everything else the read-only code set, and `.env*` the secret mode.
+fn hardenTree(allocator: std.mem.Allocator, io: Io, root: []const u8, m: Modes) void {
+    util.chmodPath(io, root, m.dir);
+
+    var dir = Dir.cwd().openDir(io, root, .{ .iterate = true }) catch return;
+    defer dir.close(io);
+    var it = dir.iterate();
+    while (it.next(io) catch null) |entry| {
+        if (skipped(entry.name)) continue;
+        const child = std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, entry.name }) catch continue;
+        switch (entry.kind) {
+            // A symlink's mode bits are not consulted by anything; chmod would
+            // follow it and rewrite a target that may sit outside the project.
+            .sym_link => continue,
+            .directory => {
+                if (contains(&writable_subdirs, entry.name)) {
+                    applyTree(allocator, io, child, m.writable_dir, m.writable_file, 32);
+                } else {
+                    applyTree(allocator, io, child, m.dir, m.file, 32);
+                }
+            },
+            .file => chmodFile(io, child, if (std.mem.startsWith(u8, entry.name, ".env")) m.secret else m.file),
+            else => {},
+        }
+    }
+}
+
+/// Recursively chmod one subtree. Depth-limited and best-effort, matching
+/// `util.chmodTreeWritable`: a directory that cannot be opened is skipped
+/// rather than failing the command. 32 is chosen to clear a real `vendor/`,
+/// which routinely nests past the 8 the writable-dirs pass uses.
+fn applyTree(allocator: std.mem.Allocator, io: Io, path: []const u8, dir_mode: u32, file_mode: u32, depth: usize) void {
+    util.chmodPath(io, path, dir_mode);
+    if (depth == 0) return;
+
+    var dir = Dir.cwd().openDir(io, path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
+    var it = dir.iterate();
+    while (it.next(io) catch null) |entry| {
+        if (skipped(entry.name)) continue;
+        const child = std.fmt.allocPrint(allocator, "{s}/{s}", .{ path, entry.name }) catch continue;
+        switch (entry.kind) {
+            .sym_link => continue,
+            .directory => applyTree(allocator, io, child, dir_mode, file_mode, depth - 1),
+            .file => chmodFile(io, child, file_mode),
+            else => {},
+        }
+    }
+}
+
+/// chmod one regular file to `mode`, KEEPING it executable if it already was.
+///
+/// A flat `chmod 0640` over the tree is the obvious implementation and it
+/// breaks the install: `bin/psp`, `vendor/bin/*` and every shipped shell script
+/// lose their exec bit, and the failure surfaces as "command not found" long
+/// after this command reported success. The exec bit is re-granted exactly
+/// where `mode` grants read, so it never widens access beyond the profile.
+fn chmodFile(io: Io, path: []const u8, mode: u32) void {
+    const current = util.statMode(io, path) orelse {
+        util.chmodPath(io, path, mode);
+        return;
+    };
+    util.chmodPath(io, path, withExecBit(mode, (current & 0o111) != 0));
+}
+
+/// `mode`, plus an execute bit wherever `mode` already grants READ — and only
+/// when the file was executable to begin with. Deriving x from r rather than
+/// hardcoding 0o111 is what keeps the profile intact: under --production a
+/// script comes out 0750, not 0751, so "no access for other" still holds for
+/// the one class of file where a stray x bit is worth the most to an attacker.
+fn withExecBit(mode: u32, executable: bool) u32 {
+    if (!executable) return mode;
+    return mode | ((mode & 0o444) >> 2);
+}
+
+fn skipped(name: []const u8) bool {
+    return contains(&harden_skip, name);
+}
+
+fn contains(haystack: []const []const u8, needle: []const u8) bool {
+    for (haystack) |h| {
+        if (std.mem.eql(u8, h, needle)) return true;
+    }
+    return false;
 }
 
 // --------------------------------------------------------------------------
 // ownership
 // --------------------------------------------------------------------------
 
-/// chown var/ and userdata/ (recursively) to `owner`, reporting each path's
-/// outcome explicitly — unlike chmod, a failed chown in production (wrong
-/// privileges, a typo'd user/group) is exactly the kind of thing that should
-/// NOT fail silently: the web server would still be unable to write.
+/// chown the whole project to `owner`, reporting the outcome explicitly —
+/// unlike chmod, a failed chown (wrong privileges, a typo'd user/group) is
+/// exactly the kind of thing that should NOT fail silently: the web server
+/// would still be unable to read the code or write its logs.
+///
+/// `.git` is chowned separately — it is not, so that the deploy user keeps
+/// being able to `git pull` after a `sudo hkm install`. That is why the root
+/// itself is chowned non-recursively and each top-level entry individually,
+/// rather than one `chown -R` over the project.
 fn fixOwnership(allocator: std.mem.Allocator, io: Io, env: *EnvMap, root: []const u8, owner: []const u8) void {
-    if (@import("builtin").os.tag == .windows) {
-        prompt.warn("--owner is not supported on Windows — skipped.");
+    var failed: usize = 0;
+
+    if (!chownPath(io, env, root, owner, false)) failed += 1;
+
+    var dir = Dir.cwd().openDir(io, root, .{ .iterate = true }) catch {
+        prompt.warn("Could not read the project root — ownership left unchanged.");
         return;
+    };
+    defer dir.close(io);
+
+    var it = dir.iterate();
+    while (it.next(io) catch null) |entry| {
+        if (skipped(entry.name)) continue;
+        const child = std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, entry.name }) catch continue;
+        if (!chownPath(io, env, child, owner, true)) failed += 1;
     }
 
-    var ok: usize = 0;
-    var total: usize = 0;
-    for ([_][]const u8{ "var", "userdata" }) |sub| {
-        const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ root, sub }) catch continue;
-        if (!util.dirExists(Dir.cwd(), io, path)) continue;
-        total += 1;
-        if (chownPath(io, env, path, owner)) {
-            ok += 1;
-        } else {
-            prompt.warn(std.fmt.allocPrint(
-                allocator,
-                "chown {s} {s} failed — needs root/sudo, or that user/group doesn't exist.",
-                .{ owner, sub },
-            ) catch "chown failed — needs root/sudo, or that user/group doesn't exist.");
-        }
-    }
-
-    if (total > 0 and ok == total) {
-        prompt.ok(std.fmt.allocPrint(allocator, "var/ and userdata/ owned by {s}", .{owner}) catch "var/ and userdata/ ownership fixed");
+    if (failed == 0) {
+        prompt.ok(std.fmt.allocPrint(allocator, "Project owned by {s} (.git left as-is)", .{owner}) catch "Ownership fixed");
+    } else {
+        prompt.warn(std.fmt.allocPrint(
+            allocator,
+            "chown {s} failed on {d} path(s) — needs root/sudo, or that user/group doesn't exist.",
+            .{ owner, failed },
+        ) catch "chown failed — needs root/sudo, or that user/group doesn't exist.");
     }
 }
 
-/// `chown -R <owner> <path>`. Shells out rather than resolving the user/group
+/// `chown [-R] <owner> <path>`. Shells out rather than resolving the user/group
 /// name to a uid/gid natively — the OS's own NSS already knows how to do that
 /// correctly (files, LDAP, whatever `/etc/nsswitch.conf` says), and `chown`
 /// already accepts `user`, `user:group` and `:group` (group-only) verbatim, so
 /// passing `owner` straight through keeps that flexibility for free. Returns
 /// whether the process exited 0.
-fn chownPath(io: Io, env: *EnvMap, path: []const u8, owner: []const u8) bool {
+fn chownPath(io: Io, env: *EnvMap, path: []const u8, owner: []const u8, recursive: bool) bool {
     const chown_bin = env.get("HKM_CHOWN_BIN") orelse "chown";
+    const argv: []const []const u8 = if (recursive)
+        &.{ chown_bin, "-R", owner, path }
+    else
+        &.{ chown_bin, owner, path };
+
     var child = std.process.spawn(io, .{
-        .argv = &.{ chown_bin, "-R", owner, path },
+        .argv = argv,
         .environ_map = env,
         .stdin = .ignore,
         .stdout = .ignore,
@@ -428,6 +683,44 @@ fn chownPath(io: Io, env: *EnvMap, path: []const u8, owner: []const u8) bool {
         .exited => |code| code == 0,
         else => false,
     };
+}
+
+// --------------------------------------------------------------------------
+// traversal
+// --------------------------------------------------------------------------
+
+/// Report ancestor directories the web server account cannot pass through.
+///
+/// Getting the project's OWN permissions right is not sufficient: to open
+/// `/home/deploy/shop/app/public_html/index.php` the pool needs execute on
+/// EVERY directory down the path, and a home directory is 0700 on a stock
+/// Debian install. Nothing inside the project can fix that, and the resulting
+/// failure reads as a permission error on a file whose mode bits are visibly
+/// correct — so name the actual directory instead of leaving it to be guessed.
+///
+/// Reported, never changed: widening a directory that is not part of the
+/// project is the operator's call, not this command's.
+fn reportTraversal(allocator: std.mem.Allocator, io: Io, root: []const u8) void {
+    var blocked: std.ArrayList([]const u8) = .empty;
+
+    var cursor: ?[]const u8 = util.parentOf(root);
+    while (cursor) |path| : (cursor = util.parentOf(path)) {
+        if (util.statMode(io, path)) |mode| {
+            // No execute for "other" — reachable only by the owner or a member
+            // of the directory's group, which a web server account rarely is.
+            if ((mode & 0o001) == 0) {
+                blocked.append(allocator, std.fmt.allocPrint(allocator, "{s} ({o})", .{ path, mode }) catch path) catch {};
+            }
+        }
+        if (std.mem.eql(u8, path, "/")) break;
+    }
+
+    if (blocked.items.len == 0) return;
+
+    prompt.warn("The web server may not be able to REACH the project — these parent directories deny traversal to others:");
+    for (blocked.items) |item| prompt.muted(std.fmt.allocPrint(allocator, "  {s}", .{item}) catch item);
+    prompt.muted("Each one needs execute for the pool's account: `chmod o+x <dir>`, add the account to its group, or");
+    prompt.muted("move the project somewhere the web server already reaches (/var/www, /srv).");
 }
 
 // --------------------------------------------------------------------------
@@ -547,4 +840,79 @@ fn composerInstall(allocator: std.mem.Allocator, io: Io, env: *EnvMap, root: []c
         },
         else => prompt.warn("composer install was interrupted."),
     }
+}
+
+// --------------------------------------------------------------------------
+// tests
+// --------------------------------------------------------------------------
+
+test "withExecBit leaves a non-executable file's mode alone" {
+    try std.testing.expectEqual(@as(u32, 0o640), withExecBit(0o640, false));
+    try std.testing.expectEqual(@as(u32, 0o664), withExecBit(0o664, false));
+    try std.testing.expectEqual(@as(u32, 0o660), withExecBit(0o660, false));
+}
+
+test "withExecBit re-grants x exactly where the mode grants r" {
+    // The regression this guards: a flat chmod 0640 over the tree strips the
+    // exec bit from bin/psp and vendor/bin/*, and the install only looks like
+    // it worked until the first invocation.
+    try std.testing.expectEqual(@as(u32, 0o750), withExecBit(0o640, true));
+    try std.testing.expectEqual(@as(u32, 0o775), withExecBit(0o664, true));
+    try std.testing.expectEqual(@as(u32, 0o770), withExecBit(0o660, true));
+}
+
+test "withExecBit never widens beyond the profile" {
+    // --production grants nothing to "other", so neither may the exec bit.
+    for ([_]u32{ 0o640, 0o660, 0o600 }) |mode| {
+        try std.testing.expectEqual(@as(u32, 0), withExecBit(mode, true) & 0o007);
+    }
+}
+
+test "production modes deny other, dev modes keep the previous defaults" {
+    const prod = Modes.of(true);
+    try std.testing.expectEqual(@as(u32, 0o2750), prod.dir);
+    try std.testing.expectEqual(@as(u32, 0o640), prod.file);
+    try std.testing.expectEqual(@as(u32, 0o2770), prod.writable_dir);
+    try std.testing.expectEqual(@as(u32, 0o660), prod.writable_file);
+    for ([_]u32{ prod.dir, prod.file, prod.writable_dir, prod.writable_file, prod.secret }) |m| {
+        try std.testing.expectEqual(@as(u32, 0), m & 0o007);
+    }
+
+    // Dev keeps the historic 0775/0664 for the runtime tree (what the pre-
+    // hardening `fixPermissions` applied), but code is only world-READABLE.
+    const dev = Modes.of(false);
+    try std.testing.expectEqual(@as(u32, 0o2755), dev.dir);
+    try std.testing.expectEqual(@as(u32, 0o644), dev.file);
+    try std.testing.expectEqual(@as(u32, 0o2775), dev.writable_dir);
+    try std.testing.expectEqual(@as(u32, 0o664), dev.writable_file);
+}
+
+test "both profiles make var/ group-writable and setgid, and .env group-readable" {
+    for ([_]Modes{ Modes.of(true), Modes.of(false) }) |m| {
+        // group write on the runtime tree — the pool has to write logs
+        try std.testing.expect(m.writable_dir & 0o020 != 0);
+        try std.testing.expect(m.writable_file & 0o020 != 0);
+        // setgid on BOTH trees: the writable one so a file the pool creates
+        // keeps the deploy user's group, the code one so a deploy that pulls
+        // new files does not un-share them from the pool.
+        try std.testing.expect(m.writable_dir & 0o2000 != 0);
+        try std.testing.expect(m.dir & 0o2000 != 0);
+        // group READ but never group WRITE on .env — FPM reads APP_KEY, and a
+        // 0600 .env is the most common reason an FPM boot fails on a tree that
+        // runs fine from the shell.
+        try std.testing.expect(m.secret & 0o040 != 0);
+        try std.testing.expectEqual(@as(u32, 0), m.secret & 0o020);
+        try std.testing.expectEqual(@as(u32, 0), m.secret & 0o007);
+        // code is never group-writable — an FPM pool that can rewrite the PHP
+        // it executes turns any file-write bug into code execution.
+        try std.testing.expectEqual(@as(u32, 0), m.file & 0o020);
+        try std.testing.expectEqual(@as(u32, 0), m.dir & 0o020);
+    }
+}
+
+test "skipped protects .git and nothing else" {
+    try std.testing.expect(skipped(".git"));
+    try std.testing.expect(!skipped("var"));
+    try std.testing.expect(!skipped(".env"));
+    try std.testing.expect(!skipped("vendor"));
 }

--- a/tools/src/lib/util.zig
+++ b/tools/src/lib/util.zig
@@ -241,6 +241,17 @@ pub fn chmodPath(io: Io, path: []const u8, mode: u32) void {
     Dir.cwd().setFilePermissions(io, path, @enumFromInt(mode), .{}) catch {};
 }
 
+/// A path's current mode bits, or null when it cannot be stat'd (gone, or a
+/// directory this process may not look into). Symlinks are NOT followed: the
+/// caller is fixing permissions inside a tree, and a symlink's target is
+/// routinely outside it — following one would rechmod a file the walk never
+/// intended to touch. Always null on Windows, which has no mode bits.
+pub fn statMode(io: Io, path: []const u8) ?u32 {
+    if (@import("builtin").os.tag == .windows) return null;
+    const st = Dir.cwd().statFile(io, path, .{ .follow_symlinks = false }) catch return null;
+    return @intFromEnum(st.permissions) & 0o7777;
+}
+
 /// Recursively make `path` writable: `dirMode` (e.g. 0o775) on every directory
 /// including `path` itself, `fileMode` (e.g. 0o664) on every regular file
 /// beneath it. Fixes a runtime tree (var/, userdata/) left behind by a

--- a/tools/src/tests.zig
+++ b/tools/src/tests.zig
@@ -27,6 +27,7 @@ const std = @import("std");
 test {
     _ = @import("commands/cli.zig");
     _ = @import("commands/discover.zig");
+    _ = @import("commands/install.zig");
     _ = @import("commands/doctor.zig");
     _ = @import("commands/list.zig");
     _ = @import("commands/module.zig");


### PR DESCRIPTION
Promotes `## [Unreleased]` to `## [1.12.0] - 2026-09-02`. Merging this pushes the `v1.12.0` tag and runs the release workflow.

## Why

`hkm install --production --owner=` only ever touched `var/` and `userdata/`, so every directory a request actually reads — `app/public_html`, `src/`, `vendor/`, `plugins/` — kept the deploying user's ownership and whatever mode the clone arrived with. The pool could write logs it was never going to reach the code to produce.

Reported from a live server, where the same tree ran fine from the shell and failed under PHP-FPM with `Permission denied` on `plugins/View/Support/helpers.php` (read) and `var/cache/manifests/*.tmp` (write).

## Fixed

- **Scope and ordering.** The pass now covers the whole project tree, and runs LAST. `composer install` and the plugin fetch both create files (`vendor/`, `plugins/`) as whoever ran the command, so running at step 3 meant the two largest directories in the project were created *after* the permissions were "fixed".
- **`.env` was `0600`.** No pool running as another account can read `APP_KEY` through that; the boot dies on a file whose mode bits look deliberate. Now `0640` — group-readable, never group-writable, never world-anything.
- **Traversal was never reported.** Reaching `app/public_html/index.php` needs execute on every parent directory, and a home directory is `0700` on a stock Debian install. Unfixable from inside the project, so the offending parents are now named — reported only, never changed.
- **The installed kernel was left at the installing account's umask** (`tools/install.sh`). `/opt/hkm-kernel` is shared infrastructure: every pool on the box loads its PHP from that one tree, none of them runs as the installing account, and `umask 027`/`077` left it unreadable to all of them — while the install reported success, because the installer could obviously read what it had just written.

## The model

Split ownership: code owned by the deploy user, reachable by the web server through the GROUP.

| Path | `--production` | `--owner` alone |
|---|---|---|
| code dirs / files | `2750` / `0640` | `2755` / `0644` |
| already-executable files | `0750` | `0755` |
| `var/`, `userdata/` | `2770` / `0660` | `2775` / `0664` |
| `.env` | `0640` | `0640` |
| `.git` | untouched | untouched |

- Code is **never group-writable** in either profile — an FPM pool that can rewrite the PHP it executes turns any file-write bug into code execution.
- **Every** directory carries setgid, code included, so a file a later deploy lands does not take the deploying account's primary group and drop out of the share.
- An already-executable file **keeps its exec bit**, re-granted only where the profile grants read (`0640` → `0750`, never `0751`). A flat `chmod 0640` strips `bin/psp` and `vendor/bin/*`, and that only surfaces at the first invocation.
- `.git` is skipped by both the chown and the chmod, so a `sudo hkm install` does not cost the deploy account its `git pull`.
- The pass re-stats what it changed and reports any mode the filesystem refused, rather than reporting success for a chmod the kernel rejected.

`--owner=:www-data` (group only) is the form for a tree deployed by a CI account: it changes the group and leaves the owner alone.

## Tests

`commands/install.zig` had no coverage and is now in the suite (`tools/src/tests.zig`). Six tests cover the exec-bit derivation and both mode profiles — one of them caught a real defect while it was being written: the non-production profile had code at `0664`, i.e. group-writable source.

- Zig: 159 pass
- PHP: 389 tests, 723 assertions, green
- `sh -n tools/install.sh` clean
- Reproduced the reported server failure on a synthetic tree (`plugins/` and `var/cache/manifests` at `0700`) and confirmed `0750` / `2770` after

**Not verified:** never run against a real Linux server, a real `www-data`, or a live FPM request. `chown` was exercised with a stub binary, so what is proven locally is the argv and the resulting mode bits.